### PR TITLE
Adding new add_mgmtazn_role Ansible role

### DIFF
--- a/add_mgmtazn_role/README.md
+++ b/add_mgmtazn_role/README.md
@@ -1,0 +1,50 @@
+Role Name
+=========
+
+Use this Role to Add One or More Custom Management Authorization Roles to the ISAM Appliance.
+
+Requirements
+------------
+
+start_config role is a required dependencies. It contains the Ansible Custom Modules and handlers.
+
+Role Variables
+--------------
+
+Provide the name of the new management authorization roles
+```
+  mgmtazn_role_names:
+    - Role 1
+    - Role 2
+```
+
+The role automatically takes a snapshot before adding roles, override as needed:
+`add_mgmtazn_role_comment: "Automated Snapshot Before Adding Management Authorization Roles"`
+
+Dependencies
+------------
+
+start_config is a required role - since it contains the Ansible Custom Modules and Handlers.
+
+Example Playbook
+----------------
+
+Here is an example of how to use this role:
+
+    - hosts: servers
+      connection: local
+      roles:
+         - role: add_mgmtazn_role
+           mgmtazn_role_name:
+             - Role 1
+             - Role 2
+
+License
+-------
+
+Apache
+
+Author Information
+------------------
+
+Ryan Dunn (rdunn1121@gmail.com)

--- a/add_mgmtazn_role/defaults/main.yml
+++ b/add_mgmtazn_role/defaults/main.yml
@@ -1,0 +1,7 @@
+# Provide the name of the new management authorization role(s)
+# mgmtazn_role_names:
+#   - Role 1
+#   - Role 2
+
+# Comment to be used for creating a snapshot file
+add_mgmtazn_role_comment: "Automated Snapshot Before Adding Management Authorization Roles"

--- a/add_mgmtazn_role/meta/main.yml
+++ b/add_mgmtazn_role/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to add one or more custom management authorization roles in ISAM
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - management_authorization
+  - role
+
+dependencies:
+  - start_config

--- a/add_mgmtazn_role/tasks/main.yml
+++ b/add_mgmtazn_role/tasks/main.yml
@@ -1,0 +1,27 @@
+- name: Snapshot Appliance Before Adding Management Authorization Roles
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.snapshots.create
+    isamapi:
+      comment: "{{ add_mgmtazn_role_comment }}"
+
+- name: Add Management Authorization Roles
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.management_authorization.role.add
+    isamapi:
+      name: "{{ item }}"
+  with_items: "{{ mgmtazn_role_names }}"
+  when: mgmtazn_role_names is defined
+  notify: Commit Changes
+


### PR DESCRIPTION
This Ansible role creates custom management authorization roles within ISAM appliances.  It leverages the existing functionality within the core ibmsecurity Python engine.