### PR TITLE
Set keystore description role

### DIFF
--- a/set_keystore_desc/README.md
+++ b/set_keystore_desc/README.md
@@ -1,0 +1,38 @@
+# Role Name
+
+Use this Role to set a description for a keystore on the ISAM Appliance.
+
+## Requirements
+
+start_config role is a required dependencies. It contains the Ansible Custom Modules and handlers.
+
+## Role Variables
+
+The following values are required:
+* set_keystore_desc_keystore
+* set_keystore_desc_description
+
+## Dependencies
+
+start_config role is a required dependencies. It contains the Ansible Custom Modules and handlers.
+
+## Example Playbook
+
+Here is an example on how to use this role:
+
+    - name: Set description for sample keystore
+      hosts: primary_master
+      connection: local
+      roles:
+        - start_config
+        - role: set_keystore_desc
+          set_keystore_desc_keystore: 'keystore id'
+          set_keystore_desc_description: 'Description of Sample keystore'
+
+## License
+
+Apache
+
+## Author Information
+
+Dries Eestermans (dries.eestermans@is4u.be)

--- a/set_keystore_desc/defaults/main.yml
+++ b/set_keystore_desc/defaults/main.yml
@@ -1,0 +1,4 @@
+# The following argument is required
+# set_keystore_desc_keystore: 'keystore_id'
+# set_keystore_desc_description: 'Description of sample keystore'
+#

--- a/set_keystore_desc/meta/main.yml
+++ b/set_keystore_desc/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to set keystore description
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - keystore
+  - description
+
+dependencies:
+- start_config

--- a/set_keystore_desc/tasks/main.yml
+++ b/set_keystore_desc/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Set keystore description {{ set_certificate_db_keystore }}
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.ssl_certificates.certificate_databases.set
+    isamapi:
+      cert_id: "{{ set_keystore_desc_keystore }}"
+      description: "{{ set_keystore_desc_description }}"
+  when: set_keystore_desc_keystore is defined and set_keystore_desc_description is defined
+  notify: Commit Changes


### PR DESCRIPTION
Provided ISAM Ansible role in order to set a description on a keystore on the ISAM Appliance.