### PR TITLE
Remove AAC references in task name

### DIFF
--- a/add_reverseproxy_conf/tasks/main.yml
+++ b/add_reverseproxy_conf/tasks/main.yml
@@ -1,5 +1,5 @@
 # Update existing stanza(s)/entries in reverse proxy config file
-- name: Configure Reverse Proxy for AAC (Updates)
+- name: Configure Reverse Proxy stanza(s) entries (Adds)
   isam:
     appliance: "{{ inventory_hostname }}"
     username:  "{{ username }}"

--- a/delete_reverseproxy_conf/tasks/main.yml
+++ b/delete_reverseproxy_conf/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Configure Reverse Proxy for AAC (Deletes)
+- name: Configure Reverse Proxy stanza(s) entries (Deletes)
   isam:
     appliance: "{{ inventory_hostname }}"
     username:  "{{ username }}"

--- a/update_reverseproxy_conf/tasks/main.yml
+++ b/update_reverseproxy_conf/tasks/main.yml
@@ -1,5 +1,5 @@
 # Update existing stanza(s)/entries in reverse proxy config file
-- name: Configure Reverse Proxy for AAC (Updates)
+- name: Configure Reverse Proxy stanza(s) entries (Updates)
   isam:
     appliance: "{{ inventory_hostname }}"
     username:  "{{ username }}"


### PR DESCRIPTION
As discussed, cleaned-up AAC reference in generic configuration proxy task names (#38)