### PR TITLE
Adding adminProxy Support to isam module

### DIFF
--- a/add_interfaces/defaults/main.yml
+++ b/add_interfaces/defaults/main.yml
@@ -1,0 +1,17 @@
+# The following need to be provided for role to work
+# Example:
+#  interfaces:
+#      -   label:  '1.1'
+#          addresses:
+#              -   address:            "192.168.1.1"
+#                  maskOrPrefix:       "24"
+#                  allowManagement:    true
+#                  enabled:            true
+#              -   address:            "192.168.1.2"
+#                  maskOrPrefix:       "24"
+#                  allowManagement:    false
+#                  enabled:            true
+# Default values for adding an ipv4 address - override as needed
+#
+# possible values: [interfaces_ipv4, interfaces_ipv6, interfaces_vlan]
+add_interfaces_action: interfaces_ipv4 

--- a/add_interfaces/meta/main.yml
+++ b/add_interfaces/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to add an address to an interface
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - networking
+
+dependencies:
+  - start_config

--- a/add_interfaces/tasks/main.yml
+++ b/add_interfaces/tasks/main.yml
@@ -25,7 +25,7 @@
 #       maskOrPrefix:       "24"
 #       allowManagement:    false
 #       enabled:            true
-- name: add interfaces [interfaces]
+- name: add interfaces
   isam:
     appliance: "{{ inventory_hostname }}"
     adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"

--- a/add_interfaces/tasks/main.yml
+++ b/add_interfaces/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# Adding interface with custom isamapi parameters
+# Therefore combining label with interface parameter:
+# Example: 
+#  inventroy:
+#    - label:  '1.1'
+#      addresses:
+#       - address:            "192.168.230.130"
+#         maskOrPrefix:       "24"
+#         allowManagement:    true
+#         enabled:            true
+#       - address:            "192.168.230.131"
+#         maskOrPrefix:       "24"
+#         allowManagement:    false
+#         enabled:            true
+#  modul transformation:
+#   item:
+#     - label: '1.1'
+#       address:            "192.168.230.130"
+#       maskOrPrefix:       "24"
+#       allowManagement:    true
+#       enabled:            true
+#     - label: '1.1'
+#       address:            "192.168.230.131"
+#       maskOrPrefix:       "24"
+#       allowManagement:    false
+#       enabled:            true
+- name: add interfaces [interfaces]
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    action: "ibmsecurity.isam.base.network.{{ add_interfaces_action }}.add"
+    isamapi: "{{ {} | combine(item.0) | combine(item.1) }}"
+  with_subelements:
+    -   "{{ interfaces }}"
+    -   addresses
+  notify: Commit Changes

--- a/first_steps/defaults/main.yml
+++ b/first_steps/defaults/main.yml
@@ -6,7 +6,6 @@ force: false
 
 # LMI FIPS options
 FIPS_cfg: { fipsEnabled: true, tlsv10Enabled: false, tlsv11Enabled: true }
-fips_restart_wait_time: 1
 
 lmi_session_timeout: 720
 

--- a/first_steps/tasks/firststeps.yml
+++ b/first_steps/tasks/firststeps.yml
@@ -3,143 +3,101 @@
 #
 #     accept service agreements
 #     set up LMI FIPS
-#     restart LMI
 #     change password
+#     commit and restart appliance
 #
 # accept service agreements
 - name: Accept Service Agreements
   isam:
-    appliance: "{{inventory_hostname}}"
-    username: admin
-    password: admin
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
+    password:  admin
+    lmi_port:  "{{ port | default(omit) }}"
     action: ibmsecurity.isam.base.service_agreement.set
-
-- name: Get Last Boot Timestamp
-  isam:
-    appliance: "{{inventory_hostname}}"
-    username: admin
-    password: admin
-    action: ibmsecurity.isam.base.firmware.get
-  check_mode: no
-  register: ret_obj
-
-- name: Extract Last Boot Timestamp
-  set_fact:
-    last_boot: "{{ret_obj.data[0].last_boot}}"
 
 # set up LMI FIPS
 - name: Setup FIPS Mode
   isam:
-    appliance: "{{inventory_hostname}}"
-    username: admin
-    password: admin
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
+    password:  admin
+    lmi_port:  "{{ port | default(omit) }}"
     action: ibmsecurity.isam.base.fips.set
     isamapi:
-      fipsEnabled: "{{FIPS_cfg.fipsEnabled}}"
-      tlsv10Enabled: "{{FIPS_cfg.tlsv10Enabled}}"
-      tlsv11Enabled: "{{FIPS_cfg.tlsv11Enabled}}"
+        fipsEnabled: "{{FIPS_cfg.fipsEnabled}}"
+        tlsv10Enabled: "{{FIPS_cfg.tlsv10Enabled}}"
+        tlsv11Enabled: "{{FIPS_cfg.tlsv11Enabled}}"
   register: ret_obj
-  when: first_steps_fips
-- debug: var=ret_obj
+  when: FIPS_cfg is defined and FIPS_cfg.fipsEnabled == true and first_steps_fips == true
 
 # Restart after FIPS if needed
 - name: Restart after enabling FIPS
   isam:
-      appliance: "{{inventory_hostname}}"
-      username: admin
-      password: admin
-      action: ibmsecurity.isam.base.fips.restart
-  when: first_steps_fips and ret_obj.data.reboot is defined and ret_obj.data.reboot == true
-
-- name: Pause for Reboot {{fips_restart_wait_time}}mins
-  pause:
-    minutes: "{{fips_restart_wait_time}}"
-  when: first_steps_fips and ret_obj.data.reboot is defined and ret_obj.data.reboot == true
-
-# Make sure system restarted
-- name: Check FIPS settings for System Online Status
-  isam:
-    appliance: "{{inventory_hostname}}"
-    username: admin
-    password: admin
-    action: ibmsecurity.isam.base.firmware.get
-  register: result
-  retries: 5
-  delay: 30
-  ignore_errors: true
-  until: result.rc == 0 and (result.data[0].last_boot != last_boot)
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
+    password:  admin
+    lmi_port:  "{{ port | default(omit) }}"
+    action: ibmsecurity.isam.base.fips.restart_and_wait
   when: first_steps_fips and ret_obj.data.reboot is defined and ret_obj.data.reboot == true
 
 # Complete the appliance set up
 - name: Complete Appliance Setup
   isam:
-    appliance: "{{inventory_hostname}}"
-    username: admin
-    password: admin
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
+    password:  admin
+    lmi_port:  "{{ port | default(omit) }}"
     action: ibmsecurity.isam.base.setup_complete.set
-  register: ret_obj
-- debug: var=ret_obj
 
 # Change password
 - name: Change password for admin user
   isam: 
-      appliance: "{{inventory_hostname}}"
-      password: "admin"
-      action: ibmsecurity.isam.base.admin.set_pw
-      isamapi:
-          'oldPassword': 'admin'
-          'newPassword': "{{password}}"
-          'sessionTimeout': "{{lmi_session_timeout}}"
-  when: first_steps_admin_pwd
-
-- name: Get LMI Last Restart Timestamp
-  isam:
     appliance: "{{ inventory_hostname }}"
-    username:  "{{ username }}"
-    password:  "{{ password }}"
-    lmi_port:  "{{ lmi_port }}"
-    log:       "{{ log_level }}"
-    force:     "{{ force }}"
-    action: ibmsecurity.isam.base.lmi.get
-  check_mode: no
-  register: ret_obj
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
+    password:  admin
+    lmi_port:  "{{ port | default(omit) }}"
+    action: ibmsecurity.isam.base.admin.set_pw
+    isamapi:
+        'oldPassword': 'admin'
+        'newPassword': "{{ password }}"
+        'sessionTimeout': "{{ lmi_session_timeout }}"
+  when: first_steps_admin_pwd == true
 
-- name: Extract LMI Restart Timestamp
-  set_fact:
-    old_start_time: "{{ret_obj.data[0].start_time}}"
-  when: not ansible_check_mode
-
+# Commit changes and restart LMI
 - name: Commit Changes and Restart LMI
   isam:
     appliance: "{{ inventory_hostname }}"
-    username:  "{{ username }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
     password:  "{{ password }}"
-    lmi_port:  "{{ lmi_port }}"
-    log:       "{{ log_level }}"
-    force:     "{{ force }}"
-    action: ibmsecurity.isam.appliance.commit_and_restart
-  when: not ansible_check_mode
-
-- name: Wait for 1 minute
-  pause:
-      minutes: 1
-  when: not ansible_check_mode
-
-- name: Wait for LMI to Respond
-  isam:
-      appliance: "{{inventory_hostname}}"
-      username: "{{username}}"
-      password: "{{password}}"
-      action: ibmsecurity.isam.base.lmi.await_startup
-      isamapi:
-          start_time: "{{old_start_time}}"
-          wait_time: "{{start_config_wait_time}}"
-  retries: 5
-  delay: 30
-  ignore_errors: true
-  when: not ansible_check_mode
-
-- name: Fail Appliance if Running in Check Mode
-  fail:
-    msg: Appliance does not have First Steps Executed. No task will run successfully so failing.
-  when: ansible_check_mode
+    lmi_port:  "{{ port | default(omit) }}"
+    action: ibmsecurity.isam.appliance.commit_and_restart_and_wait

--- a/start_config/handlers/main.yml
+++ b/start_config/handlers/main.yml
@@ -12,10 +12,9 @@
     username:  "{{ username }}"
     password:  "{{ password }}"
     lmi_port:  "{{ port | default(omit) }}"
-    log:       "{{ log_level }}"
-    force:     "{{ force }}"
-    action: ibmsecurity.isam.appliance.commit_and_restart
-  notify: Await Appliance Commit LMI Response
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.appliance.commit_and_restart_and_wait
 
 # Commit and Restart may cause LMI to restart - so wait to be safe
 - name: Await Appliance Commit LMI Response

--- a/start_config/handlers/main.yml
+++ b/start_config/handlers/main.yml
@@ -4,9 +4,14 @@
 - name: Commit Changes
   isam:
     appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
     username:  "{{ username }}"
     password:  "{{ password }}"
-    lmi_port:  "{{ lmi_port }}"
+    lmi_port:  "{{ port | default(omit) }}"
     log:       "{{ log_level }}"
     force:     "{{ force }}"
     action: ibmsecurity.isam.appliance.commit_and_restart


### PR DESCRIPTION
Introducing the AdminProxy parameters (adminProxyProtocol, adminProxyHostname, adminProxyPort, adminProxyApplianceShortName, omitAdminProxy) to the isam module.

E.g. 
(1) https://adminProxy.ibm.com/isam.ibm.com

  adminProxyProtocol=https (optional)
  adminProxyHostname=isam.ibm.com
  adminProxyPort=443 (optional)
(2) https://adminPrxy.ibm.com/isam
  adminProxyProtocol=https (optional)
  adminProxyHostname=isam.ibm.com (necessary for hostname configuration)
  adminProxyPort=443 (optional)
  adminProxyApplianceShortName=true
  
(3) https://isam.ibm.com
  adminProxyProtocol=https (optional)
  adminProxyHostname=isam.ibm.com
  adminProxyPort=443 (optional)
  omitAdminProxy=true (can be used on command line for bypassing the adminProxy)