### PR TITLE
3 major changes: AdminProxy support, new roles (hierarchically structured), exclude filter

### DIFF
--- a/aac/configure_api_protection_clients/defaults/main.yml
+++ b/aac/configure_api_protection_clients/defaults/main.yml
@@ -1,0 +1,5 @@
+# Default variables for add or update of api protection clients
+api_protection: []
+
+# variables to control whether to configure one client at a time or everything from the configurations
+client_name: "{{ item.1.name }}"

--- a/aac/configure_api_protection_clients/meta/main.yml
+++ b/aac/configure_api_protection_clients/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to add or update api protection clients
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - api_protection_clients
+
+dependencies:
+  - start_config

--- a/aac/configure_api_protection_clients/tasks/main.yml
+++ b/aac/configure_api_protection_clients/tasks/main.yml
@@ -1,0 +1,40 @@
+# main task to add or update api protection definition
+#   Example:
+#     api_protection:
+#       definitions:
+#         - name: oauth-provider
+#           description: API protection for Signal Iduna OAuth service provider
+#           grantTypes:
+#             - AUTHORIZATION_CODE
+#           tcmBehavior: NEVER_PROMPT
+#           clients: 
+#             - name: TestApp
+#               companyName: IBM demo client for OAuth flows
+#               redirectUri: 
+#                 - https://localhost
+#               contractType: ADMINISTRATIVE
+#               definitionName: oauth-provider
+---
+- name: Configure api protection client
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.api_protection.clients.set
+    isamapi: "{{ item.1 | combine({ 'definitionName': item.0.name }) }}"
+  when: item.1.name == client_name
+  with_subelements: 
+    - "{{ api_protection.definitions | default([])}}"
+    - clients
+    - skip_missing: True
+  loop_control:
+    label: "{ 'definitionName': {{ item.0.name }}, 'client_name': {{ item.1.name }} }"
+  notify: Commit Changes

--- a/aac/configure_api_protection_definitions/defaults/main.yml
+++ b/aac/configure_api_protection_definitions/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for configuration of api protection definitions
+api_protection: []

--- a/aac/configure_api_protection_definitions/meta/main.yml
+++ b/aac/configure_api_protection_definitions/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to create api protection definition
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - api_protection_definition
+
+dependencies:
+  - start_config

--- a/aac/configure_api_protection_definitions/tasks/main.yml
+++ b/aac/configure_api_protection_definitions/tasks/main.yml
@@ -1,0 +1,27 @@
+# main task to configure api protection definition
+#   Example:
+#     api_protection:
+#       definitions:
+#         - name: oauth-provider
+#           description: API protection for Signal Iduna OAuth service provider
+#           grantTypes:
+#             - AUTHORIZATION_CODE
+#           tcmBehavior: NEVER_PROMPT
+---
+- name: Configure api protection definitions
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.api_protection.definitions.set
+    isamapi: "{{ item | exclude('clients') | exclude('mapping_rules') }}"
+  with_items: "{{ api_protection.definitions | default() }}"
+  notify: Commit Changes

--- a/aac/configure_mapping_rules/defaults/main.yml
+++ b/aac/configure_mapping_rules/defaults/main.yml
@@ -1,0 +1,6 @@
+# Default variables for configuration of mapping rules
+mapping_rules: []
+
+# Default variables to filter for configuration of specific mapping rules at runtime
+name: "{{ item.name }}"
+category: "{{ item.category }}"

--- a/aac/configure_mapping_rules/meta/main.yml
+++ b/aac/configure_mapping_rules/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to configure mapping rules
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - update
+  - mapping_rules
+
+dependencies:
+  - start_config

--- a/aac/configure_mapping_rules/tasks/main.yml
+++ b/aac/configure_mapping_rules/tasks/main.yml
@@ -1,0 +1,23 @@
+# main task to configure mapping rules
+---
+- name: Configure mapping rules
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.mapping_rules.set
+    isamapi:
+      name: "{{ item.name }}"
+      category: "{{ item.category }}"
+      upload_filename: "{{ inventory_dir }}/{{ item.file }}"
+  when: item.name == name and item.category == category
+  with_items: "{{ mapping_rules }}"
+  notify: Commit Changes

--- a/aac/create_api_protection_clients/defaults/main.yml
+++ b/aac/create_api_protection_clients/defaults/main.yml
@@ -1,0 +1,5 @@
+# Default variables for creation of api protection clients
+api_protection: []
+
+# variables to control whether to configure one client at a time or everything from the configurations
+client_name: "{{ item.1.name }}"

--- a/aac/create_api_protection_clients/meta/main.yml
+++ b/aac/create_api_protection_clients/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to create api protection clients
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - api_protection_clients
+
+dependencies:
+  - start_config

--- a/aac/create_api_protection_clients/tasks/main.yml
+++ b/aac/create_api_protection_clients/tasks/main.yml
@@ -1,0 +1,40 @@
+# main task to create api protection definition
+#   Example:
+#     api_protection:
+#       definitions:
+#         - name: oauth-provider
+#           description: API protection for Signal Iduna OAuth service provider
+#           grantTypes:
+#             - AUTHORIZATION_CODE
+#           tcmBehavior: NEVER_PROMPT
+#           clients: 
+#             - name: TestApp
+#               companyName: IBM demo client for OAuth flows
+#               redirectUri: 
+#                 - https://localhost
+#               contractType: ADMINISTRATIVE
+#               definitionName: oauth-provider
+---
+- name: Create api protection client
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.api_protection.clients.add
+    isamapi: "{{ item.1 | combine({ 'definitionName': item.0.name }) }}"
+  when: item.1.name == client_name
+  with_subelements: 
+    - "{{ api_protection.definitions | default([]) }}"
+    - clients
+    - skip_missing: True
+  loop_control:
+    label: "{ 'definitionName': {{ item.0.name }}, 'clients[i].name': {{ item.1.name }} }"
+  notify: Commit Changes

--- a/aac/create_api_protection_definitions/defaults/main.yml
+++ b/aac/create_api_protection_definitions/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for creation of api protection definitions
+api_protection: []

--- a/aac/create_api_protection_definitions/meta/main.yml
+++ b/aac/create_api_protection_definitions/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to create api protection definition
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - api_protection_definition
+
+dependencies:
+  - start_config

--- a/aac/create_api_protection_definitions/tasks/main.yml
+++ b/aac/create_api_protection_definitions/tasks/main.yml
@@ -1,0 +1,27 @@
+# main task to create api protection definition
+#   Example:
+#     api_protection:
+#       definitions:
+#         - name: oauth-provider
+#           description: API protection for Signal Iduna OAuth service provider
+#           grantTypes:
+#             - AUTHORIZATION_CODE
+#           tcmBehavior: NEVER_PROMPT
+---
+- name: Create api protection definition
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.api_protection.definitions.add
+    isamapi: "{{ item | exclude('clients') | exclude('mapping_rules') }}"
+  with_items: "{{ api_protection.definitions | default([]) }}"
+  notify: Commit Changes

--- a/aac/create_authentication_mechanisms/defaults/main.yml
+++ b/aac/create_authentication_mechanisms/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for creation of authentication mechanisms
+authentication_mechanisms: []

--- a/aac/create_authentication_mechanisms/meta/main.yml
+++ b/aac/create_authentication_mechanisms/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to create authentication mechanisms
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - authentication_mechanism
+
+dependencies:
+  - start_config

--- a/aac/create_authentication_mechanisms/tasks/main.yml
+++ b/aac/create_authentication_mechanisms/tasks/main.yml
@@ -1,0 +1,37 @@
+# main task to create authentication mechanisms
+#   Example:
+#     authentication_mechanisms:
+#       - name: MappinRule1
+#         uri: "urn:ibm:security:authentication:asf:mechanism:mappingRule1"
+#         description: "Mapping Rule 1"
+#         typeName: InfoMapAuthenticationName
+#         properties:     
+#           - key: infoMap.HTMLPage
+#             value: ""
+#           - key: infoMap.JSRule
+#             value: MappingRule1
+---
+- name: Create authentication mechanisms
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.authentication.mechanisms.add
+    isamapi:
+      name:               "{{ item.name }}"
+      uri:                "{{ item.uri  }}"
+      description:        "{{ item.description | default('') }}"
+      attributes:         "{{ item.attributes | default([]) }}"
+      properties:         "{{ item.properties | default([]) }}"
+      predefined:         "{{ item.predefined | default('False') }}"
+      typeName:           "{{ item.typeName | default([]) }}"
+  with_items: "{{ authentication_mechanisms }}"
+  notify: Commit Changes

--- a/aac/create_authentication_policies/defaults/main.yml
+++ b/aac/create_authentication_policies/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for creation of authentication policies
+authentication_policies: []

--- a/aac/create_authentication_policies/meta/main.yml
+++ b/aac/create_authentication_policies/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to create authentication policies
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - authentication_policy
+
+dependencies:
+  - start_config

--- a/aac/create_authentication_policies/tasks/main.yml
+++ b/aac/create_authentication_policies/tasks/main.yml
@@ -1,0 +1,33 @@
+# main task for creation of authentication policies
+# Example:
+#   authentication_policies:
+#     - name: authPolicy1
+#       mechUri: "urn:ibm:security:authentication:asf:mechanism:authPolicy1"
+#       uri:            "urn:ibm:security:authentication:asf:authPolicy1"
+#       description:    "authentication policy 1"
+#       enabled:        "True"
+---
+- name: Create authentication policies
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.authentication.policies.set
+    isamapi:
+      name: "{{ item.name }}"
+      check_mode: "false"
+      uri: "{{ item.uri }}"
+      policy: "<Policy xmlns='urn:ibm:security:authentication:policy:1.0:schema' PolicyId='{{ item.uri }}'><Description>{{ item.description }}</Description><Step id='{{ item.uri | to_uuid }}' type='Authenticator'><Authenticator id='{{ item.mechUri | to_uuid }}' AuthenticatorId='{{ item.mechUri }}'/></Step></Policy>"
+      description: "{{ item.description | default('') }}"
+      dialect: "{{ item.dialect | default('urn:ibm:security:authentication:policy:1.0:schema') }}"
+      enabled: "{{ item.enabled | default('False') }}"
+  with_items: "{{ authentication_policies }}"
+  notify: Commit Changes

--- a/aac/update_api_protection_clients/defaults/main.yml
+++ b/aac/update_api_protection_clients/defaults/main.yml
@@ -1,0 +1,5 @@
+# Default variables for update of api protection clients
+api_protection: []
+
+# variables to control whether to configure one client at a time or everything from the configurations
+client_name: "{{ item.1.name }}"

--- a/aac/update_api_protection_clients/meta/main.yml
+++ b/aac/update_api_protection_clients/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to update api protection clients
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - api_protection_clients
+
+dependencies:
+  - start_config

--- a/aac/update_api_protection_clients/tasks/main.yml
+++ b/aac/update_api_protection_clients/tasks/main.yml
@@ -1,0 +1,40 @@
+# main task to create api protection definition
+#   Example:
+#     api_protection:
+#       definitions:
+#         - name: oauth-provider
+#           description: API protection for Signal Iduna OAuth service provider
+#           grantTypes:
+#             - AUTHORIZATION_CODE
+#           tcmBehavior: NEVER_PROMPT
+#           clients: 
+#             - name: TestApp
+#               companyName: IBM demo client for OAuth flows
+#               redirectUri: 
+#                 - https://localhost
+#               contractType: ADMINISTRATIVE
+#               definitionName: oauth-provider
+---
+- name: Create api protection client
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.api_protection.clients.update
+    isamapi: "{{ item.1 | combine({ 'definitionName': item.0.name }) }}"
+  when: item.1.name == client_name
+  with_subelements: 
+    - "{{ api_protection.definitions | default([]) }}"
+    - clients
+    - skip_missing: True
+  loop_control:
+    label: "{ 'definitionName': {{ item.0.name }}, 'clients[i].name': {{ item.1.name }} }"
+  notify: Commit Changes

--- a/aac/update_mapping_rules/defaults/main.yml
+++ b/aac/update_mapping_rules/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for updating mapping rules
+mapping_rules: []

--- a/aac/update_mapping_rules/meta/main.yml
+++ b/aac/update_mapping_rules/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to update mapping rules
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - update
+  - mapping_rules
+
+dependencies:
+  - start_config

--- a/aac/update_mapping_rules/tasks/main.yml
+++ b/aac/update_mapping_rules/tasks/main.yml
@@ -1,0 +1,21 @@
+# main task to update mapping rules
+---
+- name: Update mapping rules
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.mapping_rules.update
+    isamapi:
+      name: "{{ item.name }}"
+      content: "{{ lookup('file', inventory_dir + '/' + item.file) | replace('\n', '\\n') | replace('\"','\\\"') }}"
+  with_items: "{{ mapping_rules }}"
+  notify: Commit Changes

--- a/aac/upload_mapping_rules/defaults/main.yml
+++ b/aac/upload_mapping_rules/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for uploading mapping rules
+mapping_rules: []

--- a/aac/upload_mapping_rules/meta/main.yml
+++ b/aac/upload_mapping_rules/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to upload mapping rules
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - upload
+  - mapping_rules
+
+dependencies:
+  - start_config

--- a/aac/upload_mapping_rules/tasks/main.yml
+++ b/aac/upload_mapping_rules/tasks/main.yml
@@ -1,0 +1,23 @@
+# main task to upload mapping rules
+---
+- name: Upload mapping rules
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.mapping_rules.upload
+    isamapi:
+      name: "{{ item.name }}"
+      filename: "{{ item.file | basename }}"
+      upload_filename: "{{ inventory_dir }}/{{ item.file }}"
+      category: "{{ item.category }}"
+  with_items: "{{ mapping_rules }}"
+  notify: Commit Changes

--- a/base/activate_modules/defaults/main.yml
+++ b/base/activate_modules/defaults/main.yml
@@ -1,0 +1,10 @@
+# Provide valid module identifiers - they can be wga, mga or federation
+# activate_module_id: 'wga'
+
+# Provide the activation code for the version of ISAM
+# The activation code can be read from the activation files downloaded from
+# IBM Passport Advantage
+# activate_module_code: 'xxxx-xxxx-xxxx...'
+
+# Comment to be used for creating a snapshot file
+activate_module_comment: "Automated Snapshot Before Activating"

--- a/base/activate_modules/meta/main.yml
+++ b/base/activate_modules/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to activate multiple modules in ISAM
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - activation
+
+dependencies:
+  - start_config

--- a/base/activate_modules/tasks/main.yml
+++ b/base/activate_modules/tasks/main.yml
@@ -1,0 +1,25 @@
+- name: Activate Modules
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.activation.set
+    isamapi:
+      id:     "{{ item.id }}"
+      code:   "{{ item.code }}"
+  when: item is defined and item.id is defined and item.code is defined
+  with_items: "{{ activation_keys }}"
+  notify: Commit Changes and Restart
+  loop_control:
+    label: "{u'id': u'{{ item.id }}'}"
+
+ # Commit activation of module before doing anything else
+- meta: flush_handlers

--- a/base/add_interfaces/defaults/main.yml
+++ b/base/add_interfaces/defaults/main.yml
@@ -1,0 +1,17 @@
+# The following need to be provided for role to work
+# Example:
+#  interfaces:
+#      -   label:  '1.1'
+#          addresses:
+#              -   address:            "192.168.1.1"
+#                  maskOrPrefix:       "24"
+#                  allowManagement:    true
+#                  enabled:            true
+#              -   address:            "192.168.1.2"
+#                  maskOrPrefix:       "24"
+#                  allowManagement:    false
+#                  enabled:            true
+# Default values for adding an ipv4 address - override as needed
+#
+# possible values: [interfaces_ipv4, interfaces_ipv6, interfaces_vlan]
+add_interfaces_action: interfaces_ipv4 

--- a/base/add_interfaces/meta/main.yml
+++ b/base/add_interfaces/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to add an address to an interface
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - networking
+
+dependencies:
+  - start_config

--- a/base/add_interfaces/tasks/main.yml
+++ b/base/add_interfaces/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# Adding interface with custom isamapi parameters
+# Therefore combining label with interface parameter:
+# Example: 
+#  inventroy:
+#    - label:  '1.1'
+#      addresses:
+#       - address:            "192.168.230.130"
+#         maskOrPrefix:       "24"
+#         allowManagement:    true
+#         enabled:            true
+#       - address:            "192.168.230.131"
+#         maskOrPrefix:       "24"
+#         allowManagement:    false
+#         enabled:            true
+#  modul transformation:
+#   item:
+#     - label: '1.1'
+#       address:            "192.168.230.130"
+#       maskOrPrefix:       "24"
+#       allowManagement:    true
+#       enabled:            true
+#     - label: '1.1'
+#       address:            "192.168.230.131"
+#       maskOrPrefix:       "24"
+#       allowManagement:    false
+#       enabled:            true
+- name: add interfaces
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: "ibmsecurity.isam.base.network.{{ add_interfaces_action }}.add"
+    isamapi: "{{ {} | combine(item.0) | combine(item.1) }}"
+  with_subelements:
+    -   "{{ interfaces }}"
+    -   addresses
+  notify: Commit Changes

--- a/base/create_snapshot/defaults/main.yml
+++ b/base/create_snapshot/defaults/main.yml
@@ -1,0 +1,3 @@
+# default variables for snaphot creation
+# Example:
+#   snapshot_comment: "Test"

--- a/base/create_snapshot/meta/main.yml
+++ b/base/create_snapshot/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to create snapshot
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - snapshot
+
+dependencies:
+  - start_config

--- a/base/create_snapshot/tasks/main.yml
+++ b/base/create_snapshot/tasks/main.yml
@@ -1,0 +1,18 @@
+# main task to create snapshots
+- name: Snapshot Appliance
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.snapshots.create
+    isamapi:
+      comment: "{{ snapshot_comment }}"
+  when: snapshot_comment is defined

--- a/base/create_ssl_certificate_databases/defaults/main.yml
+++ b/base/create_ssl_certificate_databases/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for create ssl certificate database
+create_certificate_databases: []  

--- a/base/create_ssl_certificate_databases/meta/main.yml
+++ b/base/create_ssl_certificate_databases/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to create ssl certificate databases
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - ssl_certificate_databases
+
+dependencies:
+  - start_config

--- a/base/create_ssl_certificate_databases/tasks/main.yml
+++ b/base/create_ssl_certificate_databases/tasks/main.yml
@@ -1,0 +1,24 @@
+# main task for creating certificate databases
+# Example inventory:
+#  create_certificate_databases:
+#      kdb_id: "{{ item.kdb_id }}"
+---
+- name: Create certificate databases
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.ssl_certificates.certificate_databases.create
+    isamapi:
+      kdb_name: "{{ item.kdb_name }}"
+      type:  kdb
+  with_items: "{{ create_certificate_databases }}"
+  notify: Commit Changes

--- a/base/delete_interfaces/defaults/main.yml
+++ b/base/delete_interfaces/defaults/main.yml
@@ -1,0 +1,18 @@
+# The following is needed to be provided for role to work
+# Example:
+#  interfaces:
+#      -   label:  '1.1'
+#          addresses:
+#              -   address:            "192.168.1.1"
+#                  maskOrPrefix:       "24"
+#                  allowManagement:    true
+#                  enabled:            true
+#          #   -   address:            "192.168.1.2"
+#          #        maskOrPrefix:       "24"
+#          #        allowManagement:    false
+#          #        enabled:            true
+# Attention: commented out or missing addresses will be deleted by this role
+# Default values for deleting an ipv4 interface - override as needed
+#
+# possible values: [ipv4, ipv6, vlan]
+delete_interfaces_action: ipv4 

--- a/base/delete_interfaces/meta/main.yml
+++ b/base/delete_interfaces/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to add an address to an interface
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - networking
+
+dependencies:
+  - start_config

--- a/base/delete_interfaces/tasks/main.yml
+++ b/base/delete_interfaces/tasks/main.yml
@@ -1,0 +1,53 @@
+# The following is needed to be provided for role to work
+# Example:
+#  interfaces:
+#      -   label:  '1.1'
+#          addresses:
+#              -   address:            "192.168.1.1"
+#                  maskOrPrefix:       "24"
+#                  allowManagement:    true
+#                  enabled:            true
+#          #   -   address:            "192.168.1.2"
+#          #        maskOrPrefix:       "24"
+#          #        allowManagement:    false
+#          #        enabled:            true
+# Attention: commented out or missing addresses will be deleted by this role
+- name: get all interfaces
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.network.interfaces.get_all
+  register: ret_obj
+- name: delete interfaces
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: "ibmsecurity.isam.base.network.interfaces_{{ delete_interfaces_action }}.delete"
+    isamapi:
+      label:    "{{ item.0.label }}"
+      address:  "{{ item.1.address }}"
+  vars:
+    filter: "[? label=='{{ item.0.label }}'].addresses[].address"
+  when: item.1.address not in (interfaces | json_query(filter))
+  with_subelements:
+   - "{{ ret_obj | json_query('data.interfaces[*].{label: label, addresses: ipv4.addresses[]}') }}"
+   - addresses
+  notify: Commit Changes

--- a/base/export_certificates/defaults/main.yml
+++ b/base/export_certificates/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for exporting certificates from databases
+export_certificates: []

--- a/base/export_certificates/meta/main.yml
+++ b/base/export_certificates/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to export certificates from databases
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - export
+  - certificates
+
+dependencies:
+  - start_config

--- a/base/export_certificates/tasks/main.yml
+++ b/base/export_certificates/tasks/main.yml
@@ -1,0 +1,29 @@
+# main task for exporting certificates
+# Example inventory:
+#  export_certificates:
+#      kdb_id:     "{{ item.kdb_id }}"
+#      cert_id:    "{{ item.cert_id }}"
+#      filename:   "{{ inventory_dir }}/{{ item.filename }}"
+---
+- name: Create local directory structure
+  file: path="{{ inventory_dir }}/{{ item.filename | dirname }}" state=directory
+  with_items: "{{ export_certificates }}"
+- name: Export certificates
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.ssl_certificates.personal_certificate.export_cert
+    isamapi:
+      kdb_id:     "{{ item.kdb_id }}"
+      cert_id:    "{{ item.cert_id }}"
+      filename:   "{{ inventory_dir }}/{{ item.filename }}"
+  with_items: "{{ export_certificates }}"

--- a/base/extract_certificates/defaults/main.yml
+++ b/base/extract_certificates/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for extracting certificates from database
+extract_certificates: []

--- a/base/extract_certificates/meta/main.yml
+++ b/base/extract_certificates/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to extract certificates from database
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - extract
+  - certificates
+
+dependencies:
+  - start_config

--- a/base/extract_certificates/tasks/main.yml
+++ b/base/extract_certificates/tasks/main.yml
@@ -1,0 +1,35 @@
+# main task for extracting certificates
+# Example inventory:
+#  extract_certificates:
+#      kdb_id:     "{{ item.kdb_id }}"
+#      cert_id:    "{{ item.cert_id }}"
+#      password:   "{{ item.password }}"
+#      filename:   "{{ inventory_dir }}/{{ item.filename }}"
+---
+- name: Create local directory structure
+  file: path="{{ inventory_dir }}/{{ item.filename | dirname }}" state=directory
+  with_items: "{{ extract_certificates }}"
+  loop_control:
+    label: "{u'kdb_id': u'{{ item.kdb_id }}', u'cert_id': u'{{ item.cert_id }}', u'filename': u'{{ inventory_dir }}/{{ item.filename }}'}"
+- name: Extract certificates
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.ssl_certificates.personal_certificate.extract_cert
+    isamapi:
+      kdb_id:     "{{ item.kdb_id }}"
+      cert_id:    "{{ item.cert_id }}"
+      password:   "{{ item.password }}"
+      filename:   "{{ inventory_dir }}/{{ item.filename }}"
+  with_items: "{{ extract_certificates }}"
+  loop_control:
+    label: "{u'kdb_id': u'{{ item.kdb_id }}', u'password': u'*****', u'cert_id': u'{{ item.cert_id }}', u'filename': u'{{ inventory_dir }}/{{ item.filename }}'}"

--- a/base/first_steps/defaults/main.yml
+++ b/base/first_steps/defaults/main.yml
@@ -1,0 +1,14 @@
+lmi_port: 443
+username: admin
+password: admin
+log_level: INFO
+force: false
+
+# LMI FIPS options
+FIPS_cfg: { fipsEnabled: true, tlsv10Enabled: false, tlsv11Enabled: true }
+
+lmi_session_timeout: 720
+
+# Override this setting if you do not want FIPS mode to be turned on
+first_steps_fips: True
+first_steps_admin_pwd: True

--- a/base/first_steps/meta/main.yml
+++ b/base/first_steps/meta/main.yml
@@ -1,0 +1,15 @@
+galaxy_info:
+  author: IBM
+  description: Role that executes first steps on an appliance that has just been built
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+
+dependencies:
+  - start_config

--- a/base/first_steps/tasks/firststeps.yml
+++ b/base/first_steps/tasks/firststeps.yml
@@ -1,0 +1,103 @@
+---
+# task file for ISAM appliance first steps
+#
+#     accept service agreements
+#     set up LMI FIPS
+#     change password
+#     commit and restart appliance
+#
+# accept service agreements
+- name: Accept Service Agreements
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
+    password:  admin
+    lmi_port:  "{{ port | default(omit) }}"
+    action: ibmsecurity.isam.base.service_agreement.set
+
+# set up LMI FIPS
+- name: Setup FIPS Mode
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
+    password:  admin
+    lmi_port:  "{{ port | default(omit) }}"
+    action: ibmsecurity.isam.base.fips.set
+    isamapi:
+        fipsEnabled: "{{FIPS_cfg.fipsEnabled}}"
+        tlsv10Enabled: "{{FIPS_cfg.tlsv10Enabled}}"
+        tlsv11Enabled: "{{FIPS_cfg.tlsv11Enabled}}"
+  register: ret_obj
+  when: FIPS_cfg is defined and FIPS_cfg.fipsEnabled == true and first_steps_fips == true
+
+# Restart after FIPS if needed
+- name: Restart after enabling FIPS
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
+    password:  admin
+    lmi_port:  "{{ port | default(omit) }}"
+    action: ibmsecurity.isam.base.fips.restart_and_wait
+  when: first_steps_fips and ret_obj.data.reboot is defined and ret_obj.data.reboot == true
+
+# Complete the appliance set up
+- name: Complete Appliance Setup
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
+    password:  admin
+    lmi_port:  "{{ port | default(omit) }}"
+    action: ibmsecurity.isam.base.setup_complete.set
+
+# Change password
+- name: Change password for admin user
+  isam: 
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
+    password:  admin
+    lmi_port:  "{{ port | default(omit) }}"
+    action: ibmsecurity.isam.base.admin.set_pw
+    isamapi:
+        'oldPassword': 'admin'
+        'newPassword': "{{ password }}"
+        'sessionTimeout': "{{ lmi_session_timeout }}"
+  when: first_steps_admin_pwd == true
+
+# Commit changes and restart LMI
+- name: Commit Changes and Restart LMI
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  admin
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    action: ibmsecurity.isam.appliance.commit_and_restart_and_wait

--- a/base/first_steps/tasks/main.yml
+++ b/base/first_steps/tasks/main.yml
@@ -1,0 +1,28 @@
+# check whether ISAM appliance LMI is ready and accept default password
+- name: Check ISAM appliance for First Steps Execution
+  uri:
+    url: "https://{{inventory_hostname}}/lmi"
+    user: admin
+    password: admin
+    method: GET
+    return_content: yes
+    force_basic_auth: yes
+    status_code: 200, 403
+    validate_certs: false
+    HEADER_Accept: "application/json"
+  check_mode: no
+  register: result
+
+- name: Assume First Steps Executed
+  set_fact:
+    firststeps: "skip_fs.yml"
+
+# if default password fails we do not go through firststeps and change password
+- name: Initiate logic if First Steps Required
+  set_fact:
+    firststeps: "firststeps.yml"
+  when: result is defined and result.status == 200 and result.json.sla is defined
+
+# Go through basic set up to accept license and set up FIPS only needed
+- include: "{{firststeps}}"
+  dynamic: true

--- a/base/first_steps/tasks/skip_fs.yml
+++ b/base/first_steps/tasks/skip_fs.yml
@@ -1,0 +1,3 @@
+---
+# do nothing
+- meta: noop

--- a/base/generate_self_signed_certificates/defaults/main.yml
+++ b/base/generate_self_signed_certificates/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for generatin self signed certificates
+generate_self_signed_certificates: []

--- a/base/generate_self_signed_certificates/meta/main.yml
+++ b/base/generate_self_signed_certificates/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - self_signed_certificates
+  - generate
+
+dependencies:
+  - start_config

--- a/base/generate_self_signed_certificates/tasks/main.yml
+++ b/base/generate_self_signed_certificates/tasks/main.yml
@@ -1,0 +1,33 @@
+# main task for generating self signed certificates
+# Example inventory:
+#  generate_self_signed_certificates:
+#      kdb_id:     "{{ item.kdb_id }}"
+#      label:      "{{ item.label }}"
+#      dn:         "{{ item.dn }}"
+#      expire:     "{{ item.expire }}"
+#      default:    "{{ item.default }}"
+#      size:       "{{ item.size }}"
+---
+- name: Generate self signed certificates
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.ssl_certificates.personal_certificate.generate
+    isamapi:
+      kdb_id:     "{{ item.kdb_id }}"
+      label:      "{{ item.label }}"
+      dn:         "{{ item.dn }}"
+      expire:     "{{ item.expire }}"
+      default:    "{{ item.default }}"
+      size:       "{{ item.size }}"
+  with_items: "{{ generate_self_signed_certificates }}"
+  notify: Commit Changes

--- a/base/load_signer_certificates/defaults/main.yml
+++ b/base/load_signer_certificates/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for seamless integration
+load_signer_certificates: []

--- a/base/load_signer_certificates/meta/main.yml
+++ b/base/load_signer_certificates/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to load a signer certificate into a certificate store
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - load_signer_certificates
+
+dependencies:
+  - start_config

--- a/base/load_signer_certificates/tasks/main.yml
+++ b/base/load_signer_certificates/tasks/main.yml
@@ -1,0 +1,23 @@
+# main task: load_signer_certificates
+---
+- name: Load signer certificates into certificate store
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    lmi_port: "{{ port | default(omit) }}"
+    log: "{{ log_level | default(omit) }}"
+    force: "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.ssl_certificates.signer_certificate.load
+    isamapi:
+      kdb_id: "{{ item.kdb_id }}"
+      label: "{{ item.label }}"
+      server: "{{ item.server }}"
+      port: "{{ item.port }}"
+  with_items: "{{ load_signer_certificates }}"
+  notify: Commit Changes

--- a/base/set_host_records/defaults/main.yml
+++ b/base/set_host_records/defaults/main.yml
@@ -1,0 +1,2 @@
+# default variables for setting host file entries
+host_records: []

--- a/base/set_host_records/meta/main.yml
+++ b/base/set_host_records/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to set host file entries 
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - set
+  - host_file
+
+dependencies:
+  - start_config

--- a/base/set_host_records/tasks/main.yml
+++ b/base/set_host_records/tasks/main.yml
@@ -1,0 +1,25 @@
+# main task for setting host file entries
+# Example:
+#   host_records:
+#     - addr: 192.168.0.1
+#       hostnames:
+#	  - isam.ibm.com
+- name: Set host file entries
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.network.host_records.set
+    isamapi:
+      addr:   "{{ item.addr }}"
+      hostnames:   "{{ item.hostnames }}"
+  with_items: "{{ host_records }}"
+  notify: Commit Changes

--- a/base/set_listening_interfaces/defaults/main.yml
+++ b/base/set_listening_interfaces/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for setting listening interfaces
+listening_interfaces: []

--- a/base/set_listening_interfaces/meta/main.yml
+++ b/base/set_listening_interfaces/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to set listening interfaces
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - set
+  - listening_interfaces
+
+dependencies:
+  - start_config

--- a/base/set_listening_interfaces/tasks/main.yml
+++ b/base/set_listening_interfaces/tasks/main.yml
@@ -1,0 +1,22 @@
+# main task to set listening interfaces
+---
+- name: Set listening interfaces
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.runtime.listening_interfaces.set_by_address
+    isamapi:
+      address: "{{ item.address }}"
+      port: "{{ item.port }}"
+      secure: "{{ item.secure }}"
+  with_items: "{{ listening_interfaces }}"
+  notify: Commit Changes

--- a/base/upload_signer_certificates/defaults/main.yml
+++ b/base/upload_signer_certificates/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for uploading signer certificates
+upload_signer_certificates: []

--- a/base/upload_signer_certificates/meta/main.yml
+++ b/base/upload_signer_certificates/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to upload signer certificates
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - upload
+  - signer_certificates
+
+dependencies:
+  - start_config

--- a/base/upload_signer_certificates/tasks/main.yml
+++ b/base/upload_signer_certificates/tasks/main.yml
@@ -1,0 +1,27 @@
+# main task to upload signer certificates
+#   Example:
+#      upload_signer_certificates:
+#         -   kdb_id: "{{ item.kdb_id }}"
+#             cert: "{{ inventory_dir }}/{{ item.cert  }}"
+#             label: "{{ item.label }}"
+---
+- name: Upload signer certificates
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.ssl_certificates.signer_certificate.import_cert
+    isamapi:
+      kdb_id: "{{ item.kdb_id }}"
+      cert: "{{ inventory_dir }}/{{ item.cert  }}"
+      label: "{{ item.label }}"
+  with_items: "{{ upload_signer_certificates }}"
+  notify: Commit Changes

--- a/fed/configure_sts_chain_templates/defaults/main.yml
+++ b/fed/configure_sts_chain_templates/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for configuration of sts chain templates
+sts_chain_templates: []

--- a/fed/configure_sts_chain_templates/meta/main.yml
+++ b/fed/configure_sts_chain_templates/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to configure STS chain templates
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - sts_chain_template
+
+dependencies:
+  - start_config

--- a/fed/configure_sts_chain_templates/tasks/main.yml
+++ b/fed/configure_sts_chain_templates/tasks/main.yml
@@ -1,0 +1,29 @@
+# main task to configure sts chain templates
+#   Example: STSUU to LTPA Token
+#     sts_chain_templates:
+#       - name: STSUU_TO_LTPA_TEMPLATE
+#         description: STSUU_TO_LTPA_TEMPLATE
+#         chainItems:
+#           - id: default-stsuu
+#             mode: validate
+#           - id: default-map
+#             mode: map
+#           - id: default-ltpa
+#             mode: issue
+- name: Configure STS chain templates
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.fed.sts.templates.set
+    isamapi: "{{ item }}"
+  with_items: "{{ sts_chain_templates }}"
+  notify: Commit Changes

--- a/fed/configure_sts_chains/defaults/main.yml
+++ b/fed/configure_sts_chains/defaults/main.yml
@@ -1,0 +1,11 @@
+# Default variables for configuration of sts chains
+sts_chains: []
+
+# Default variables to filter at runtime for specific conditions
+name: "{{ item.name }}"
+chainName: "{{ item.chainName }}"
+requestType: "{{ item.requestType }}"
+issuer:
+  address: "{{ item.issuer.address }}"
+appliesTo:
+  address: "{{ item.appliesTo.address }}"

--- a/fed/configure_sts_chains/meta/main.yml
+++ b/fed/configure_sts_chains/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to configure STS chains
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - sts_chain
+
+dependencies:
+  - start_config

--- a/fed/configure_sts_chains/tasks/main.yml
+++ b/fed/configure_sts_chains/tasks/main.yml
@@ -1,0 +1,62 @@
+# main task to configure sts chains
+#   Example: STSUU to LTPA Token
+#     sts_chains:
+#       - name: TC_STSUU_TO_INFONET_LTPA_CHAIN
+#         chainName: STSUU_TO_LTPA_TEMPLATE
+#         description: Create LTPA-Token with INFONET specific DN and REALM for SI-TokenChanger
+#         requestType: http://schemas.xmlsoap.org/ws/2005/02/trust/Issue
+#         issuer:
+#           address: ISAM-STS
+#         appliesTo:
+#           address: SI-TokenChange
+#         signResponses: false
+#         validateRequests: false
+#         properties:
+#           self: 
+#             - name: uuid98f91a2f-ede5-4440-8b2e-f0bc845d967e.map.rule.type
+#               value: 
+#                 - JAVASCRIPT
+#             - name: uuid98f91a2f-ede5-4440-8b2e-f0bc845d967e.map.rule.reference.ids
+#               value:
+#                 - 18
+#             - name: uuid1bc4c3d8-cc79-4bc4-87dc-c264052a8655.ltpa.self.filename
+#               value:
+#                 - asdf.ltpa
+#             - name: uuid1bc4c3d8-cc79-4bc4-87dc-c264052a8655.ltpa.self.password
+#               value:
+#                 - asdf
+#             - name: uuid1bc4c3d8-cc79-4bc4-87dc-c264052a8655.ltpa.self.usefips
+#               value:
+#                 - false
+#             - name: uuid1bc4c3d8-cc79-4bc4-87dc-c264052a8655.ltpa.self.expiration
+#               value:
+#                 - 120
+#             - name: uuid1bc4c3d8-cc79-4bc4-87dc-c264052a8655.ltpa.self.realm
+#               value:
+#                 - "ldtinfnet.hh.signal-iduna.de\\:1389"
+#             - name: uuid1bc4c3d8-cc79-4bc4-87dc-c264052a8655.ltpa.self.version
+#               value:
+#                 - 2
+#             - name: uuid1bc4c3d8-cc79-4bc4-87dc-c264052a8655.ltpa.self.extattr
+#               value:
+#                 - "*"
+- name: Configure STS chains
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.fed.sts.module_chains.set
+    isamapi: "{{ item }}"
+  when: item.name == name and item.chainName == chainName and item.requestType == item.requestType and item.issuer.address == issuer.address and item.appliesTo.address == appliesTo.address
+  with_items: "{{ sts_chains }}"
+  notify: Commit Changes
+  loop_control:
+    label: "{ name: {{ item.name }}, chainName: {{ item.chainName }}, requestType: {{ item.requestType }}, issuer.address: {{ item.issuer.address }}, appliesTo.address: {{ item.appliesTo.address }}}"

--- a/fed/create_federation_partners/defaults/main.yml
+++ b/fed/create_federation_partners/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for creation of federation partners
+federations: []

--- a/fed/create_federation_partners/meta/main.yml
+++ b/fed/create_federation_partners/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to create federation partners
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - federation_partner
+
+dependencies:
+  - start_config

--- a/fed/create_federation_partners/tasks/main.yml
+++ b/fed/create_federation_partners/tasks/main.yml
@@ -1,0 +1,49 @@
+# main task to create federation partners
+#   Example: OIDC connect provider and Test-App partner
+#     federations:
+#       - name: oidc-provider
+#         partners:
+#             - name: Test-App
+#               enabled: true
+#               role: op
+#               configuration:
+#                 clientName: Test-App
+#                 clientSecret: "ABCDEFG12345"
+#                 clientId: Test-App
+#                 redirectUris:
+#                   - http://test-app.demo.com
+#                 responseTypes:
+#                   - id_token token
+#                 allowRefreshGrant: no
+#                 allowIntrospect: no
+#                 scope:
+#                   - openid
+#                 preauthorizedScope:
+#                   - openid
+- name: Create federation partners
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.fed.partners.set
+    isamapi:
+      federation_name: "{{ item.0.name }}"
+      partner_name: "{{ item.1.name }}"
+      enabled: "{{ item.1.enabled }}"
+      role: "{{ item.1.role }}"
+      configuration: "{{ item.1.configuration }}"
+  with_subelements :
+    - "{{ federations }}"
+    - partners
+    - skip_missing: True
+  notify: Commit Changes
+  loop_control:
+    label: "{u'federation_name': u'{{ item.0.name }}', u'partner_name': u'{{ item.1.name }}'}"

--- a/fed/create_federations/defaults/main.yml
+++ b/fed/create_federations/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for creation of federations
+federations: []

--- a/fed/create_federations/meta/main.yml
+++ b/fed/create_federations/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to create federations
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - federation
+
+dependencies:
+  - start_config

--- a/fed/create_federations/tasks/main.yml
+++ b/fed/create_federations/tasks/main.yml
@@ -1,0 +1,47 @@
+# main task to create federations
+#   Example: OIDC connect provider
+#     federations:
+#       - name: oidc-provider
+#         protocol: OIDC
+#         role: op
+#         configuration:
+#           issuerIdentifier: https://oidc/test
+#           signatureAlgorithm: RS256
+#           signingKeystore: oidc_provider_keys
+#           signingKeyLabel: OpenIdConnectProvider-nonProd
+#           authorizationCodeLength: "30"
+#           refreshTokenLength: "50"
+#           accessTokenLength: "40"
+#           authorizationCodeLifetime: "30"
+#           accessTokenLifetime: "7200"
+#           authorizationGrantLifetime: "604800"
+#           idTokenLifetime: "7200"
+#           grantTypesSupported:
+#               - implicit
+#           identityMapping:
+#             activeDelegateId: default-map
+#             properties:
+#               identityMappingRuleReference: "5"
+- name: Create federations
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.fed.federations.set
+    isamapi:
+      name: "{{ item.name }}"
+      protocol: "{{ item.protocol }}"
+      role: "{{ item.role }}"
+      configuration: "{{ item.configuration }}"
+  with_items: "{{ federations }}"
+  notify: Commit Changes
+  loop_control:
+    label: "{u'name': u'{{ item.name }}'}"

--- a/fed/set_runtime_certificates/defaults/main.yml
+++ b/fed/set_runtime_certificates/defaults/main.yml
@@ -1,0 +1,10 @@
+# Provide valid module identifiers - they can be wga, mga or federation
+# activate_module_id: 'wga'
+
+# Provide the activation code for the version of ISAM
+# The activation code can be read from the activation files downloaded from
+# IBM Passport Advantage
+# activate_module_code: 'xxxx-xxxx-xxxx...'
+
+# Comment to be used for creating a snapshot file
+activate_module_comment: "Automated Snapshot Before Activating"

--- a/fed/set_runtime_certificates/meta/main.yml
+++ b/fed/set_runtime_certificates/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to activate multiple modules in ISAM
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - activation
+
+dependencies:
+  - start_config

--- a/fed/set_runtime_certificates/tasks/main.yml
+++ b/fed/set_runtime_certificates/tasks/main.yml
@@ -1,0 +1,42 @@
+- name: Snapshot Appliance Before Activating
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.snapshots.create
+    isamapi:
+      comment: "{{ activate_module_comment }}"
+
+- name: Activate Modules
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.activation.set
+    isamapi:
+      id:     "{{ item.id }}"
+      code:   "{{ item.code }}"
+  when: item is defined and item.id is defined and item.code is defined
+  with_items: "{{ activation_keys }}"
+  notify: Commit Changes and Restart
+  loop_control:
+    label: "{u'id': u'{{ item.id }}'}"
+
+ # Commit activation of module before doing anything else
+- meta: flush_handlers

--- a/start_config/filter_plugins/exclude.py
+++ b/start_config/filter_plugins/exclude.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python
+
+from ansible import errors
+
+def exclude(a, b):
+    temp = a.copy()
+    if isinstance(a,dict):
+        temp.pop(b, None)
+    return temp
+class FilterModule(object):
+    def filters(self):
+        return {
+            'exclude': exclude
+        }

--- a/start_config/handlers/main.yml
+++ b/start_config/handlers/main.yml
@@ -4,13 +4,32 @@
 - name: Commit Changes
   isam:
     appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
     username:  "{{ username }}"
     password:  "{{ password }}"
-    lmi_port:  "{{ lmi_port }}"
-    log:       "{{ log_level }}"
-    force:     "{{ force }}"
-    action: ibmsecurity.isam.appliance.commit_and_restart
-  notify: Await Appliance Commit LMI Response
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.appliance.commit
+
+- name: Commit Changes and Restart
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.appliance.commit_and_restart_and_wait
 
 # Commit and Restart may cause LMI to restart - so wait to be safe
 - name: Await Appliance Commit LMI Response
@@ -25,11 +44,16 @@
 - name: Restart Web Runtime
   isam:
     appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
     username:  "{{ username }}"
     password:  "{{ password }}"
-    lmi_port:  "{{ lmi_port }}"
-    log:       "{{ log_level }}"
-    force:     "{{ force }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
     action: ibmsecurity.isam.web.runtime.process.execute
     isamapi:
       operation: "restart"
@@ -39,11 +63,16 @@
 - name: Restart Reverse Proxy
   isam:
     appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
     username:  "{{ username }}"
     password:  "{{ password }}"
-    lmi_port:  "{{ lmi_port }}"
-    log:       "{{ log_level }}"
-    force:     "{{ force }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
     action: ibmsecurity.isam.web.reverse_proxy.instance.get
   notify: Restart all Reverse Proxys - checks if flagged for restart
   changed_when: True
@@ -53,11 +82,16 @@
 - name: Restart all Reverse Proxys - checks if flagged for restart
   isam:
     appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
     username:  "{{ username }}"
     password:  "{{ password }}"
-    lmi_port:  "{{ lmi_port }}"
-    log:       "{{ log_level }}"
-    force:     "{{ force }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
     action: ibmsecurity.isam.web.reverse_proxy.instance.execute
     isamapi:
       id:        "{{ item.id }}"
@@ -68,11 +102,16 @@
 - name: Reload Liberty Runtime
   isam:
     appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
     username:  "{{ username }}"
     password:  "{{ password }}"
-    lmi_port:  "{{ lmi_port }}"
-    log:       "{{ log_level }}"
-    force:     "{{ force }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
     action: ibmsecurity.isam.base.runtime.process.execute
     isamapi:
       operation: "reload"
@@ -81,11 +120,16 @@
 - name: Restart AAC Runtime
   isam:
     appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
     username:  "{{ username }}"
     password:  "{{ password }}"
-    lmi_port:  "{{ lmi_port }}"
-    log:       "{{ log_level }}"
-    force:     "{{ force }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
     action: ibmsecurity.isam.base.runtime.process.execute
     isamapi:
       operation: "restart"
@@ -94,11 +138,16 @@
 - name: Reboot Appliance
   isam:
     appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
     username:  "{{ username }}"
     password:  "{{ password }}"
-    lmi_port:  "{{ lmi_port }}"
-    log:       "{{ log_level }}"
-    force:     "{{ force }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
     action: ibmsecurity.isam.appliance.reboot
   notify: Await Appliance LMI Response
   when: not ansible_check_mode
@@ -106,16 +155,17 @@
 - name: Restart LMI
   isam:
     appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
     username:  "{{ username }}"
     password:  "{{ password }}"
-    lmi_port:  "{{ lmi_port }}"
-    log:       "{{ log_level }}"
-    force:     "{{ force }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
     action: ibmsecurity.isam.base.lmi.restart
-  notify: Await Appliance LMI Response
-  when: not ansible_check_mode
-  # In case reboot happens before LMI restart - ignore errors to play safe
-  ignore_errors: yes
 
 - name: Await Appliance LMI Response
   wait_for:
@@ -125,3 +175,18 @@
     timeout: "{{ start_config_wait_time }}"
     state: started
   when: not ansible_check_mode
+  
+- name: Restart LMI and wait
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.base.lmi.restart_and_wait

--- a/start_config/library/isamadmin.py
+++ b/start_config/library/isamadmin.py
@@ -9,6 +9,7 @@ from StringIO import StringIO
 import datetime
 
 from ibmsecurity.appliance.isamappliance import ISAMAppliance
+from ibmsecurity.appliance.isamappliance_adminproxy import ISAMApplianceAdminProxy
 from ibmsecurity.appliance.ibmappliance import IBMError
 from ibmsecurity.user.applianceuser import ApplianceUser
 from ibmsecurity.user.isamuser import ISAMUser
@@ -27,7 +28,12 @@ def main():
             isamuser=dict(required=False),
             isampwd=dict(required=True),
             isamdomain=dict(required=False, default='Default'),
-            commands=dict(required=True, type='list')
+            commands=dict(required=True, type='list'),
+            adminProxyProtocol=dict(required=False, default='https', choices=['http','https']),
+            adminProxyHostname=dict(required=False),
+            adminProxyPort=dict(required=False, default=443, type='int'),
+            adminProxyApplianceShortName=dict(required=False, default=False, type='bool'),
+            omitAdminProxy=dict(required=False, default=False, type='bool')
         ),
         supports_check_mode=False
     )
@@ -44,6 +50,11 @@ def main():
     isampwd = module.params['isampwd']
     isamdomain = module.params['isamdomain']
     commands = module.params['commands']
+    adminProxyProtocol = module.params['adminProxyProtocol']
+    adminProxyHostname = module.params['adminProxyHostname']
+    adminProxyPort = module.params['adminProxyPort']
+    adminProxyApplianceShortName = module.params['adminProxyApplianceShortName']
+    omitAdminProxy = module.params['omitAdminProxy']
 
     # Setup logging for format, set log level and redirect to string
     strlog = StringIO()
@@ -83,7 +94,14 @@ def main():
         u = ApplianceUser(password=password)
     else:
         u = ApplianceUser(username=username, password=password)
-    isam_server = ISAMAppliance(hostname=appliance, user=u, lmi_port=lmi_port)
+    
+	# Create appliance object to be used for all calls
+    # if adminProxy hostname is set, use the ISAMApplianceAdminProxy
+    if adminProxyHostname == '' or adminProxyHostname is None or omitAdminProxy:
+        isam_server = ISAMAppliance(hostname=appliance, user=u, lmi_port=lmi_port)
+    else:
+        isam_server = ISAMApplianceAdminProxy(adminProxyHostname=adminProxyHostname, user=u, hostname=appliance, adminProxyProtocol=adminProxyProtocol, adminProxyPort=adminProxyPort, adminProxyApplianceShortName=adminProxyApplianceShortName)
+
     if isamuser == '' or isamuser is None:
         iu = ISAMUser(password=isampwd)
     else:

--- a/start_config/library/isamadmin.py.bak
+++ b/start_config/library/isamadmin.py.bak
@@ -12,6 +12,7 @@ from ibmsecurity.appliance.isamappliance import ISAMAppliance
 from ibmsecurity.appliance.isamappliance_adminproxy import ISAMApplianceAdminProxy
 from ibmsecurity.appliance.ibmappliance import IBMError
 from ibmsecurity.user.applianceuser import ApplianceUser
+from ibmsecurity.user.isamuser import ISAMUser
 
 logger = logging.getLogger(sys.argv[0])
 
@@ -19,33 +20,36 @@ logger = logging.getLogger(sys.argv[0])
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            log=dict(required=False, default='INFO', choices=['DEBUG', 'INFO', 'ERROR', 'CRITICAL']),
+            log=dict(default='INFO', choices=['DEBUG', 'INFO', 'ERROR', 'CRITICAL']),
             appliance=dict(required=True),
             lmi_port=dict(required=False, default=443, type='int'),
-            action=dict(required=True),
-            force=dict(required=False, default=False, type='bool'),
             username=dict(required=False),
             password=dict(required=True),
-            isamapi=dict(required=False, type='dict'),
-            adminProxyProtocol=dict(required=False, default='https', choices=['http','https']),
+            isamuser=dict(required=False),
+            isampwd=dict(required=True),
+            isamdomain=dict(required=False, default='Default'),
+            commands=dict(required=True, type='list'),
+			adminProxyProtocol=dict(required=False, default='https', choices=['http','https']),
             adminProxyHostname=dict(required=False),
             adminProxyPort=dict(required=False, default=443, type='int'),
             adminProxyApplianceShortName=dict(required=False, default=False, type='bool'),
             omitAdminProxy=dict(required=False, default=False, type='bool')
         ),
-        supports_check_mode=True
+        supports_check_mode=False
     )
 
-    module.debug('Started isam module')
+    module.debug('Started isamadmin module')
 
     # Process all Arguments
     logLevel = module.params['log']
-    force = module.params['force']
-    action = module.params['action']
     appliance = module.params['appliance']
     lmi_port = module.params['lmi_port']
     username = module.params['username']
     password = module.params['password']
+    isamuser = module.params['isamuser']
+    isampwd = module.params['isampwd']
+    isamdomain = module.params['isamdomain']
+    commands = module.params['commands']
     adminProxyProtocol = module.params['adminProxyProtocol']
     adminProxyHostname = module.params['adminProxyHostname']
     adminProxyPort = module.params['adminProxyPort']
@@ -90,70 +94,52 @@ def main():
         u = ApplianceUser(password=password)
     else:
         u = ApplianceUser(username=username, password=password)
-
-    # Create appliance object to be used for all calls
+    
+	# Create appliance object to be used for all calls
     # if adminProxy hostname is set, use the ISAMApplianceAdminProxy
     if adminProxyHostname == '' or adminProxyHostname is None or omitAdminProxy:
         isam_server = ISAMAppliance(hostname=appliance, user=u, lmi_port=lmi_port)
     else:
         isam_server = ISAMApplianceAdminProxy(adminProxyHostname=adminProxyHostname, user=u, hostname=appliance, adminProxyProtocol=adminProxyProtocol, adminProxyPort=adminProxyPort, adminProxyApplianceShortName=adminProxyApplianceShortName)
-        
-    # Create options string to pass to action method
-    options = 'isamAppliance=isam_server, force=' + str(force)
-    if module.check_mode is True:
-        options = options + ', check_mode=True'
-    if isinstance(module.params['isamapi'], dict):
-        for key, value in module.params['isamapi'].iteritems():
-            if isinstance(value, basestring):
-                options = options + ', ' + key + '="' + value + '"'
-            else:
-                options = options + ', ' + key + '=' + str(value)
-    module.debug('Option to be passed to action: ' + options)
 
-    # Dynamically process the action to be invoked
-    # Simple check to restrict calls to just "isam" ones for safety
-    if action.startswith('ibmsecurity.isam.'):
-        try:
-            module_name, method_name = action.rsplit('.', 1)
-            module.debug('Action method to be imported from module: ' + module_name)
-            module.debug('Action method name is: ' + method_name)
-            mod = importlib.import_module(module_name)
-            func_ptr = getattr(mod, method_name)  # Convert action to actual function pointer
-            func_call = 'func_ptr(' + options + ')'
-
-            startd = datetime.datetime.now()
-
-            # Execute requested 'action'
-            ret_obj = eval(func_call)
-
-            endd = datetime.datetime.now()
-            delta = endd - startd
-
-            ret_obj['stdout'] = strlog.getvalue()
-            ret_obj['stdout_lines'] = strlog.getvalue().split()
-            ret_obj['start'] = str(startd)
-            ret_obj['end'] = str(endd)
-            ret_obj['delta'] = str(delta)
-            ret_obj['cmd'] = action + "(" + options + ")"
-            ret_obj['ansible_facts'] = isam_server.facts
-
-            module.exit_json(**ret_obj)
-
-        except ImportError:
-            module.fail_json(name=action, msg='Error> action belongs to a module that is not found!',
-                             log=strlog.getvalue())
-        except AttributeError:
-            module.fail_json(name=action, msg='Error> invalid action was specified, method not found in module!',
-                             log=strlog.getvalue())
-        except TypeError:
-            module.fail_json(name=action,
-                             msg='Error> action does not have the right set of arguments or there is a code bug! Options: ' + options,
-                             log=strlog.getvalue())
-        except IBMError as e:
-            module.fail_json(name=action, msg=str(e), log=strlog.getvalue())
+    if isamuser == '' or isamuser is None:
+        iu = ISAMUser(password=isampwd)
     else:
-        module.fail_json(name=action, msg='Error> invalid action specified, needs to be isam!',
+        iu = ISAMUser(username=isamuser, password=isampwd)
+
+    try:
+        import ibmsecurity.isam.web.runtime.pdadmin
+
+        startd = datetime.datetime.now()
+
+        ret_obj = ibmsecurity.isam.web.runtime.pdadmin.execute(isamAppliance=isam_server, isamUser=iu,
+                                                               admin_domain=isamdomain, commands=commands)
+
+        endd = datetime.datetime.now()
+        delta = endd - startd
+
+        ret_obj['stdout'] = strlog.getvalue()
+        ret_obj['stdout_lines'] = strlog.getvalue().split()
+        ret_obj['start'] = str(startd)
+        ret_obj['end'] = str(endd)
+        ret_obj['delta'] = str(delta)
+        ret_obj[
+            'cmd'] = "ibmsecurity.isam.config_fed_dir.runtime.pdadmin.execute(isamAppliance=isam_server, isamUser=iu, commands=" + str(
+            commands) + ")"
+        ret_obj['ansible_facts'] = isam_server.facts
+
+        module.exit_json(**ret_obj)
+
+    except ImportError:
+        module.fail_json(name='pdadmin', msg='Error> Unable to import pdadmin module!', log=strlog.getvalue())
+    except AttributeError:
+        module.fail_json(name='pdadmin', msg='Error> Error finding execute function of pdadmin module',
                          log=strlog.getvalue())
+    except TypeError:
+        module.fail_json(name='pdadmin', msg='Error> pdadmin has wrong set of arguments or there is a bug in code!',
+                         log=strlog.getvalue())
+    except IBMError as e:
+        module.fail_json(name='pdadmin', msg=str(e), log=strlog.getvalue())
 
 
 if __name__ == '__main__':

--- a/web/configure_management_root/defaults/main.yml
+++ b/web/configure_management_root/defaults/main.yml
@@ -1,0 +1,9 @@
+# Default variables for configuration of management root content
+instances: []
+
+# variables to control whether to configure one instance and/or one target at a time or everythin from the configurations
+inst_name: "{{ item.0.inst_name }}"
+target: "{{ item.1.target | default('none') }}"
+file: "{{ item.1.file | default('none') }}"
+filename: "{{ (inventory_dir + '/' + item.1.file) if (item.1.file is defined) else 'none' }}"
+

--- a/web/configure_management_root/meta/main.yml
+++ b/web/configure_management_root/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to configuration of management root content
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - upload
+  - management_root
+
+dependencies:
+  - start_config

--- a/web/configure_management_root/tasks/include_delete_management_root_contents.yml
+++ b/web/configure_management_root/tasks/include_delete_management_root_contents.yml
@@ -1,0 +1,22 @@
+- name: Delete management root files/directories
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: "ibmsecurity.isam.web.reverse_proxy.management_root.{{ item.1.type }}.delete"
+    isamapi: 
+      id:             "{{ target }}"
+      instance_id:    "{{ item.0.inst_name }}"
+  with_items: "{{ item.1.targets }}" 
+  loop_control:
+    loop_var: target
+    label:  "(action: [{{ item.1.action }}], type: [{{ item.1.type }}], inst_name:[{{ item.0.inst_name }}], target:[{{ target }}])"
+  notify: Commit Changes

--- a/web/configure_management_root/tasks/main.yml
+++ b/web/configure_management_root/tasks/main.yml
@@ -1,0 +1,80 @@
+# main task to configure management root content
+# Example:
+#     instances:
+#       - inst_name: default
+#         management_root:
+#           - action: upload
+#             target: management/C/login.html
+#             file: uploads/management_root/default/management/C/login.html
+#           - action: delete
+#             target: errors/C/38ad52fa.html
+#             type: file
+#           - action: delete
+#             target: errors/de
+#             type: directory
+#           - action: delete
+#             type: directory
+#             targets: 
+#               - errors/de
+#               - errors/fr
+---
+- name: Upload management root files
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.reverse_proxy.management_root.file.import_file
+    isamapi:
+      id: "{{ item.1.target }}"
+      filename: "{{ inventory_dir }}/{{ item.1.file }}"
+      instance_id: "{{ item.0.inst_name }}"
+  when: item.1.action == 'upload' and item.1.target is defined and item.1.file is defined and item.0.inst_name == inst_name and item.1.target == target and item.1.file == file
+  with_subelements:
+    - "{{ instances }}"
+    - management_root
+    - skip_missing: True
+  loop_control:
+    label:  "(action: [{{ item.1.action }}], inst_name:[{{ item.0.inst_name }}], filename: [{{ filename }}], target:[{{ target }}])"
+  notify: Commit Changes
+- name: Delete management root file/directory
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: "ibmsecurity.isam.web.reverse_proxy.management_root.{{ item.1.type }}.delete"
+    isamapi: 
+      id:             "{{ item.1.target }}"
+      instance_id:    "{{ item.0.inst_name }}"
+  when: item.1.action == 'delete' and item.1.target is defined and item.1.type is defined and (item.1.type == 'file' or item.1.type == 'directory') and item.0.inst_name == inst_name and item.1.target == target
+  with_subelements:
+    - "{{ instances }}"
+    - management_root
+    - skip_missing: True
+  loop_control:
+    label:  "(action: [{{ item.1.action }}], type: [{{ item.1.type | default('file')}}], inst_name:[{{ item.0.inst_name }}], target:[{{ item.1.target | default('none') }}])"
+  notify: Commit Changes
+- include: include_delete_management_root_contents.yml
+  when: item.1.action == 'delete' and item.1.targets is defined and item.1.type is defined and (item.1.type == 'file' or item.1.type == 'directory') and item.0.inst_name == inst_name and item.1.target == target
+  with_subelements:
+    - "{{ instances }}"
+    - management_root
+    - skip_missing: True
+  loop_control:
+    label:  "(action: [{{ item.1.action }}], type: [{{ item.1.type | default('file') }}], inst_name:[{{ item.0.inst_name }}, target:[{{ item.1.target | default('none') }}])"
+  notify: Commit Changes

--- a/web/configure_policyserver/defaults/main.yml
+++ b/web/configure_policyserver/defaults/main.yml
@@ -1,0 +1,28 @@
+# Provide the following minimal values to setup Local Policy Server with Local Embedded LDAP
+#   policyserver_runtime:
+#     configuration:
+#       admin_pwd:              "{{ admin_pwd }}"
+#       ps_mode:                "local"
+#       user_registry:          "local"
+#       ldap_pwd:               "{{ ldap_pwd }}"
+#       clean_ldap:             "true"
+#       admin_cert_lifetime:    1460
+#       ssl_compliance:         "none"
+# The following are defaults to support local policy server/local embedded ldap
+# additional configuraitons can be looked up in the isam web service documentation: e.g.
+#      user_registry:       "{{ user_registry }}"
+#      ldap_host:           "{{ ldap_host }}"
+#      ldap_port:           "{{ ldap_port }}"
+#      ldap_dn:             "{{ ldap_dn }}"
+#      ldap_pwd:            "{{ ldap_pwd }}"
+#      ldap_ssl_db:         "{{ ldap_ssl_db }}"
+#      ldap_ssl_label:      "{{ ldap_ssl_label }}"
+#      ldap_suffix:         "{{ ldap_suffix }}"
+#      domain:              "{{ domain }}"
+#      isam_host:           "{{ isam_host }}"
+#      isam_port:           "{{ isam_port }}"
+policyserver_runtime:
+  configuration: []
+# By default change the "connection_inacvtivity" to be 270
+# This is meants to be lower than 5mins - when firewall typically close down unused connections
+policyserver_connection_inactivity: 270

--- a/web/configure_policyserver/meta/main.yml
+++ b/web/configure_policyserver/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role that configures a Policy Server
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - web
+  - runtime
+  - policyserver
+
+dependencies:
+  - start_config

--- a/web/configure_policyserver/tasks/main.yml
+++ b/web/configure_policyserver/tasks/main.yml
@@ -1,0 +1,52 @@
+# Generic approach for isamapi parameters
+# Following structure is supported: e.g.
+#   policyserver_runtime:
+#     configuration:
+#       admin_pwd:              "{{ admin_pwd }}"
+#       ps_mode:                "local"
+#       user_registry:          "local"
+#       ldap_pwd:               "{{ ldap_pwd }}"
+#       clean_ldap:             "true"
+#       admin_cert_lifetime:    1460
+#       ssl_compliance:         "none"
+#       ...     <- additional parameters
+- name: Configure Policy Server
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.runtime.process.config
+    isamapi: "{{ policyserver_runtime.configuration }}"
+      
+
+- name: Update Connection Inactivity to be less than infinity
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action    : ibmsecurity.isam.web.runtime.configuration.entry.update
+    isamapi:
+      resource_id : "ldap.conf"
+      stanza_id   : "ldap"
+      entry_id    : "connection-inactivity"
+      value_id    : "{{ policyserver_connection_inactivity }}"
+  when: not ansible_check_mode
+  notify:
+  - Commit Changes
+  - Restart Web Runtime

--- a/web/configure_reverseproxy_instances/defaults/main.yml
+++ b/web/configure_reverseproxy_instances/defaults/main.yml
@@ -1,0 +1,37 @@
+# Default variables for configuration of reverse proxy instances
+instances:
+  - entries: []
+  
+# variables to control whether to configure one instance and/or a specific stanza at a time or everything from the configurations
+inst_name: "{{ item.0.inst_name }}"
+stanza: "{{ item.1.stanza }}"
+entry_name: "{{ item.1.entry_name }}"
+
+# variables to manage trigger action
+action_method: "{{ 'set' if item.1.method == 'set' else
+                        'add' if item.1.method == 'add' else
+                            'delete' if item.1.method == 'delete' else
+                                'get'
+                }}"
+
+# parameter to be passed to ansible module
+action_params:
+    set:
+        reverseproxy_id: "{{ item.0.inst_name }}"
+        stanza_id:       "{{ item.1.stanza }}"
+        entries:
+                -   
+                    - "{{ item.1.entry_name }}"
+                    - "{{ item.1.value }}"
+    add:
+        reverseproxy_id: "{{ item.0.inst_name }}"
+        stanza_id:       "{{ item.1.stanza }}"
+        entries:
+                -   
+                    - "{{ item.1.entry_name }}"
+                    - "{{ item.1.value }}"
+    delete:
+        reverseproxy_id: "{{ item.0.inst_name }}"
+        stanza_id:       "{{ item.1.stanza }}"
+        entry_id: "{{ item.1.entry_name }}"
+        value_id: "{{ item.1.value }}"

--- a/web/configure_reverseproxy_instances/meta/main.yml
+++ b/web/configure_reverseproxy_instances/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to configure reverse proxy instances
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - configure
+  - reverse_proxy
+
+dependencies:
+  - start_config

--- a/web/configure_reverseproxy_instances/tasks/main.yml
+++ b/web/configure_reverseproxy_instances/tasks/main.yml
@@ -1,0 +1,29 @@
+# main task to configure reverse proxy instances
+#   Example:
+#     instances:
+#       -   inst_name: default
+#           entries:
+#               - { method: set, stanza: server, entry_name: server-name, value: default }
+---
+- name: Configure reverse proxy instances
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: "ibmsecurity.isam.web.reverse_proxy.configuration.entry.{{ action_method }}"
+    isamapi: "{{ action_params[action_method] }}"
+  with_subelements:
+    - "{{ instances }}"
+    - entries
+  when: item.0.inst_name == inst_name and item.1.stanza == stanza and item.1.entry_name == entry_name
+  loop_control:
+    label:  "(inst_name:[{{ item.0.inst_name }}], stanza: [{{ item.1.stanza }}], entry_name:[{{ item.1.entry_name }}], value:[{{ item.1.value }}])"
+  notify: Commit Changes

--- a/web/configure_reverseproxy_junctions/defaults/main.yml
+++ b/web/configure_reverseproxy_junctions/defaults/main.yml
@@ -1,0 +1,5 @@
+# Default variables for configuration of reverse proxy junctions
+
+# Configuration entry to control, if not listed junction servers should be deleted on the server
+delete_junction_server: false
+delete_junctions: false

--- a/web/configure_reverseproxy_junctions/meta/main.yml
+++ b/web/configure_reverseproxy_junctions/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to configure reverse proxy junctions
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - configure
+  - reverse_proxy_junctions
+
+dependencies:
+  - start_config

--- a/web/configure_reverseproxy_junctions/tasks/include_create_junctions.yml
+++ b/web/configure_reverseproxy_junctions/tasks/include_create_junctions.yml
@@ -1,0 +1,36 @@
+---
+- name: "Create junction [inst_name: {{ item.0.inst_name }}, junction_point: {{ item.1.junction_point }}]"
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.reverse_proxy.junctions.add
+    isamapi: "{{ item.1 | exclude('servers') | combine({'reverseproxy_id':item.0.inst_name,'server_hostname':item.1.servers[0].server_hostname,'server_port':item.1.servers[0].server_port}) }}" 
+
+- name: Add junction servers
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.reverse_proxy.junctions_server.add
+    isamapi: "{{ server | combine({'reverseproxy_id':item.0.inst_name,'junction_point': item.1.junction_point,'junction_type': item.1.junction_type}) }}" 
+  with_items: "{{ item.1.servers }}"
+  loop_control:
+    loop_var: server
+    label: "inst_name:[{{ item.0.inst_name }}], junction_point:[{{ item.1.junction_point }}], server_hostname:[{{ server.server_hostname }}], server_port:[{{ server.server_port }}]]"

--- a/web/configure_reverseproxy_junctions/tasks/include_delete_junction_server_hostnames.yml
+++ b/web/configure_reverseproxy_junctions/tasks/include_delete_junction_server_hostnames.yml
@@ -1,0 +1,44 @@
+---
+- name: Get junction servers
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.reverse_proxy.junctions.get
+    isamapi:
+      reverseproxy_id: "{{ item.0.inst_name }}"
+      junctionname: "{{ item.1.junction_point  }}"      
+  register: ret_obj
+- name: Delete junction servers
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.reverse_proxy.junctions_server.delete
+    isamapi:
+      reverseproxy_id: "{{ item.0.inst_name }}"
+      junction_point: "{{ item.1.junction_point }}"
+      server_hostname: "{{ server.server_hostname }}"
+      server_port: "{{ server.server_port }}"
+  vars:
+    filter: "[? server_hostname == '{{ server.server_hostname }}' && server_port == `{{ server.server_port }}`]"
+  when: (item.1.servers | json_query(filter)) == []
+  with_items: "{{ ret_obj | json_query('data.servers[].{server_hostname: server_hostname, server_port: server_port}') }}"
+  loop_control:
+    loop_var: server

--- a/web/configure_reverseproxy_junctions/tasks/include_delete_junctions.yml
+++ b/web/configure_reverseproxy_junctions/tasks/include_delete_junctions.yml
@@ -1,0 +1,42 @@
+---
+- name: "Get junctions for {{ item.inst_name }}"
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.reverse_proxy.junctions.get_all
+    isamapi:
+      reverseproxy_id: "{{ item.inst_name }}"
+  register: ret_obj
+- name: Delete junction 
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.reverse_proxy.junctions.delete
+    isamapi:
+      reverseproxy_id: "{{ item.inst_name }}"
+      junctionname: "{{ server.id }}"
+  vars:
+    filter: "[? inst_name == '{{ item.inst_name }}'].junctions[].junction_point"
+  when: server.id not in (instances | json_query(filter)) and server.id == (junction_point | default(server.id))
+  with_items: "{{ ret_obj.data }}"
+  loop_control:
+    loop_var: server
+    label: "{delete_junctions: {{ delete_junctions }}, inst_name: {{ item.inst_name }}, junction_point: {{ server.id }}}"

--- a/web/configure_reverseproxy_junctions/tasks/include_junctions.yml
+++ b/web/configure_reverseproxy_junctions/tasks/include_junctions.yml
@@ -1,0 +1,15 @@
+---
+# - name: initialize junction dict
+  # set_fact:
+    # junction: {}
+    # junction_point: "{{ item.1.junction_point }}"
+    # junction_type: "{{ item.1.junction_type }}"
+    # servers: "{{ item.1.servers }}"
+    # inst_name: "{{ item.0.inst_name }}"
+   
+- name: Include Create Junctions
+  include: include_create_junctions.yml
+
+- name: "Include to delete undefined junction server hostnames [delete_junction_server: {{ delete_junction_server }}, inst_name: {{ item[0].inst_name }}, junction_point: {{ item[1].junction_point }}]"
+  include: include_delete_junction_server_hostnames.yml
+  when: delete_junction_server == true

--- a/web/configure_reverseproxy_junctions/tasks/main.yml
+++ b/web/configure_reverseproxy_junctions/tasks/main.yml
@@ -1,0 +1,27 @@
+# main task to configure reverse proxy instances
+#   Example:
+#     instances:
+#       -   inst_name: default
+#           junctions:
+#             -   junction_point:             "/jct1"
+#                 junction_type:              "tcp"
+#                 servers:
+#                     -   server_hostname:    "localhost"
+#                         server_port:        443
+---
+- name: Include over all instances and junctions
+  include: include_junctions.yml
+  with_subelements:
+    - "{{ instances }}"
+    - junctions
+    - skip_missing: True
+  when: item[1].junction_point == (junction_point | default(item[1].junction_point)) and item[0].inst_name == (inst_name | default(item[0].inst_name))
+  loop_control:
+    label: "{inst_name: {{ item[0].inst_name }}, junction_point: {{ item[1].junction_point }}}"
+    
+- name: Include to delete undefined junctions
+  include: include_delete_junctions.yml
+  with_items: "{{ instances }}"
+  when: (delete_junctions == true) and item.inst_name == (inst_name | default(item.inst_name))
+  loop_control:
+    label: " {inst_name: {{ item.inst_name }}, delete_junctions: {{ delete_junctions }}}"

--- a/web/create_reverseproxy_instances/defaults/main.yml
+++ b/web/create_reverseproxy_instances/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for creation of reverse proxy instances
+instances: []

--- a/web/create_reverseproxy_instances/meta/main.yml
+++ b/web/create_reverseproxy_instances/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to create reverse proxy instance
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - create
+  - reverse_proxy
+
+dependencies:
+  - start_config

--- a/web/create_reverseproxy_instances/tasks/main.yml
+++ b/web/create_reverseproxy_instances/tasks/main.yml
@@ -1,0 +1,53 @@
+# main task to create reverse proxy instances
+# Example:
+#    instances:
+#        - inst_name: "{{ item.inst_name }}"
+#          host: "{{ item.host }}"
+#          listening_port: "{{ item.listening_port }}"
+#          domain: "{{ item.domain | default('default') }}"
+#          admin_id: "{{ item.admin_id }}"
+#          admin_pwd: "{{ item.admin_pwd }}"
+#          ssl_yn: "{{ item.ssl_yn | default('None') }}"
+#          key_file: "{{ item.key_file | default('None') }}"
+#          cert_label: "{{ item.cert_label | default('None') }}"
+#          ssl_port: "{{ item.ssl_port | default('None') }}"
+#          http_yn: "{{ item.http_yn | default('no') }}"
+#          http_port: "{{ item.http_port | default(80) }}"
+#          https_yn: "{{ item.https_yn | default('no') }}"
+#          https_port: "{{ item.https_port | default(443) }}"
+#          nw_interface_yn: "{{ item.nw_interface_yn | default('None') }}"
+#          ip_address: "{{ item.ip_address }}"
+---
+- name: Create reverse proxy instances
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.reverse_proxy.instance.add
+    isamapi:
+      inst_name: "{{ item.inst_name }}"
+      host: "{{ item.host }}"
+      listening_port: "{{ item.listening_port }}"
+      domain: "{{ item.domain | default('default') }}"
+      admin_id: "{{ item.admin_id }}"
+      admin_pwd: "{{ item.admin_pwd }}"
+      ssl_yn: "{{ item.ssl_yn | default('None') }}"
+      key_file: "{{ item.key_file | default('None') }}"
+      cert_label: "{{ item.cert_label | default('None') }}"
+      ssl_port: "{{ item.ssl_port | default('None') }}"
+      http_yn: "{{ item.http_yn | default('no') }}"
+      http_port: "{{ item.http_port | default(80) }}"
+      https_yn: "{{ item.https_yn | default('no') }}"
+      https_port: "{{ item.https_port | default(443) }}"
+      nw_interface_yn: "{{ item.nw_interface_yn | default('None') }}"
+      ip_address: "{{ item.ip_address }}"
+  with_items: "{{ instances }}"
+  notify: Commit Changes

--- a/web/create_sso_keys/defaults/main.yml
+++ b/web/create_sso_keys/defaults/main.yml
@@ -1,0 +1,5 @@
+# default values for sso key file
+# Example:
+#   sso_keys:
+#     - ssokey_name: "sso.key"
+sso_keys: []

--- a/web/create_sso_keys/meta/main.yml
+++ b/web/create_sso_keys/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to create a sso key file
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - sso_key
+
+dependencies:
+  - start_config

--- a/web/create_sso_keys/tasks/main.yml
+++ b/web/create_sso_keys/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: Create sso key file
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.sso_keys.add
+    isamapi:
+      ssokey_name: "{{ item.ssokey_name }}"
+  with_items: "{{ sso_keys }}"

--- a/web/execute_pdadmin/defaults/main.yml
+++ b/web/execute_pdadmin/defaults/main.yml
@@ -1,0 +1,7 @@
+# Provide a list of pdadmin commands to execute
+#pdadmin_commands:
+#  - "acl show default-management"
+#  - "user list * 10"
+
+# Use Default domain, override as needed
+admin_domain: Default

--- a/web/execute_pdadmin/meta/main.yml
+++ b/web/execute_pdadmin/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role that executes pdadmin commands against Policy Server
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - policy_server
+  - pdadmin
+
+dependencies:
+  - start_config

--- a/web/execute_pdadmin/tasks/main.yml
+++ b/web/execute_pdadmin/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: PDadmin
+  include: pdadmin.yml
+  when: pdadmin_commands is defined or include_pdadmin_commands is defined

--- a/web/execute_pdadmin/tasks/pdadmin.yml
+++ b/web/execute_pdadmin/tasks/pdadmin.yml
@@ -1,0 +1,27 @@
+- name: Run PDAdmin commands
+  isamadmin:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    isamuser:  "{{ admin_id }}"
+    isampwd:   "{{ admin_pwd }}"
+    isamdomain: "{{ admin_domain }}"
+    commands: "{{ pdadmin_commands | default([]) }} + {{ include_pdadmin_commands | default([]) }}"
+  ignore_errors: true
+  register: ret_obj
+
+- name: Output of PDAdmin command execution
+  debug: msg="{{ ret_obj['data']['result'].split('\n') }}"
+  when: (ret_obj is defined and 'result' in ret_obj['data'] and ret_obj|succeeded and (not ansible_check_mode))
+
+- name: Error Messages *if* PDAdmin command failed
+  debug: msg="{{ ret_obj['log'].split('\n') }}"
+  when: (ret_obj is defined and 'log' in ret_obj and ret_obj|failed and (not ansible_check_mode))

--- a/web/restart_reverseproxy_instance/defaults/main.yml
+++ b/web/restart_reverseproxy_instance/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for restarting reverse proxy instance
+instance: []

--- a/web/restart_reverseproxy_instance/meta/main.yml
+++ b/web/restart_reverseproxy_instance/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to restart reverse proxy instance
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - restart
+  - reverseproxy_instance
+
+dependencies:
+  - start_config

--- a/web/restart_reverseproxy_instance/tasks/main.yml
+++ b/web/restart_reverseproxy_instance/tasks/main.yml
@@ -1,0 +1,31 @@
+# main task to restart reverse proxy instance
+---
+- name: Prepare restart specific instance
+  set_fact:
+      instance:
+          -   inst_name: "{{ inst_name }}"
+  when: inst_name != "all"
+- name: Prepare restart all instances
+  set_fact:
+      instance: "{{ instances }}"
+  when: inst_name == "all" and instances is defined
+- name: Restart reverse proxy instance
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.reverse_proxy.instance.execute
+    isamapi:
+      id: "{{ item.inst_name }}"
+  with_items: "{{ instance | default(instances)}}"
+  loop_control:
+    label: "{'u'inst_name': u'{{ item.inst_name }}'}"
+  notify: Commit Changes

--- a/web/set_embedded_ldap_admin_pw/defaults/main.yml
+++ b/web/set_embedded_ldap_admin_pw/defaults/main.yml
@@ -1,0 +1,1 @@
+# defaults for setting embedded ldap admin password

--- a/web/set_embedded_ldap_admin_pw/meta/main.yml
+++ b/web/set_embedded_ldap_admin_pw/meta/main.yml
@@ -1,0 +1,19 @@
+galaxy_info:
+  author: IBM
+  description: Role that sets password for embedded ldap admin user
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - password
+  - embedded_ldap
+  - admin_user
+  - set
+
+dependencies:
+  - start_config

--- a/web/set_embedded_ldap_admin_pw/tasks/main.yml
+++ b/web/set_embedded_ldap_admin_pw/tasks/main.yml
@@ -1,0 +1,18 @@
+- name: Change Embedded LDAP password
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.embedded_ldap.admin.set_pw
+    isamapi:
+      password: "{{ policyserver_runtime.configuration.ldap_pwd }}"
+  when: policyserver_runtime is defined and policyserver_runtime.configuration is defined and policyserver_runtime.configuration.ldap_pwd is defined
+  notify: Commit Changes

--- a/web/set_runtime_components/defaults/main.yml
+++ b/web/set_runtime_components/defaults/main.yml
@@ -1,0 +1,3 @@
+# Default variables for setting runtime components
+policyserver_runtime: 
+  entries: []

--- a/web/set_runtime_components/meta/main.yml
+++ b/web/set_runtime_components/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to set runtime components
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - set
+  - runtime components
+
+dependencies:
+  - start_config

--- a/web/set_runtime_components/tasks/main.yml
+++ b/web/set_runtime_components/tasks/main.yml
@@ -1,0 +1,30 @@
+# main task to set runtime components
+# Example:
+#   policyserver_runtime:
+#     entries:
+#       - { resource_id: "ldap.conf", stanza_id: "bind-credentials", entry_id: "bind-dn", value_id: "{{ ldap_dn }}" }
+#       - { resource_id: "ldap.conf", stanza_id: "bind-credentials", entry_id: "bind-pwd", value_id: "{{ ldap_pwd }}" }
+---
+- name: Set runtime components
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.runtime.configuration.entry.update
+    isamapi:
+      resource_id: "{{ item.resource_id }}"
+      stanza_id: "{{ item.stanza_id }}"
+      entry_id: "{{ item.entry_id }}"
+      value_id: "{{ item.value_id }}"
+  with_items: "{{ policyserver_runtime.entries }}"
+  notify: 
+    - Commit Changes
+    - Restart Web Runtime

--- a/web/update_jmt_files/defaults/main.yml
+++ b/web/update_jmt_files/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for updating jmt files
+jmt_files: []

--- a/web/update_jmt_files/meta/main.yml
+++ b/web/update_jmt_files/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to update Junction Mapping Table (jmt) files
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - update
+  - jmt_files
+
+dependencies:
+  - start_config

--- a/web/update_jmt_files/tasks/main.yml
+++ b/web/update_jmt_files/tasks/main.yml
@@ -1,0 +1,24 @@
+# main task to upload jmt files
+# Example:
+#   jmt_files
+#     - file: uploads/jmt/jmt.conf
+---
+- name: Upload jmt files
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.junction_mapping.update
+    isamapi:
+      id: "{{ item.file | basename }}"
+      jmt_config_data: "{{ lookup('file', inventory_dir + '/' + item.file) | replace('\n', '\\n') | replace('\"','\\\"') }}"
+  with_items: "{{ jmt_files }}"
+  notify: Commit Changes

--- a/web/upload_dynurl_files/defaults/main.yml
+++ b/web/upload_dynurl_files/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for uploading jmt files
+dynurl_files: []

--- a/web/upload_dynurl_files/meta/main.yml
+++ b/web/upload_dynurl_files/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to upload dynurl files
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - upload
+  - dynurl_files
+
+dependencies:
+  - start_config

--- a/web/upload_dynurl_files/tasks/main.yml
+++ b/web/upload_dynurl_files/tasks/main.yml
@@ -1,0 +1,24 @@
+# main task to upload dynurl files
+# Example:
+#   dynurl_files
+#     - file: uploads/dynurl/dynurl.conf
+---
+- name: Upload dynurl files
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.url_mapping.import_file
+    isamapi:
+      id: "{{ item.file | basename }}"
+      filename: "{{ inventory_dir }}/{{ item.file }}"
+  with_items: "{{ dynurl_files }}"
+  notify: Commit Changes

--- a/web/upload_http_transformation_files/defaults/main.yml
+++ b/web/upload_http_transformation_files/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for uploading http transformation files
+http_transformations: []

--- a/web/upload_http_transformation_files/meta/main.yml
+++ b/web/upload_http_transformation_files/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to upload HTTP transformation files
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - upload
+  - http_tranformation
+
+dependencies:
+  - start_config

--- a/web/upload_http_transformation_files/tasks/main.yml
+++ b/web/upload_http_transformation_files/tasks/main.yml
@@ -1,0 +1,24 @@
+# main task to upload jmt files
+# Example:
+#   http_transformations
+#     - file: uploads/http_transformations/default.xslt
+---
+- name: Upload http transformation files
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.http_transformation.import_file
+    isamapi:
+      id: "{{ item.file | basename }}"
+      filename: "{{ inventory_dir }}/{{ item.file }}"
+  with_items: "{{ http_transformations }}"
+  notify: Commit Changes

--- a/web/upload_jmt_files/defaults/main.yml
+++ b/web/upload_jmt_files/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for uploading jmt files
+jmt_files: []

--- a/web/upload_jmt_files/meta/main.yml
+++ b/web/upload_jmt_files/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to upload Junction Mapping Table (jmt) files
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - upload
+  - jmt_files
+
+dependencies:
+  - start_config

--- a/web/upload_jmt_files/tasks/main.yml
+++ b/web/upload_jmt_files/tasks/main.yml
@@ -1,0 +1,24 @@
+# main task to upload jmt files
+# Example:
+#   jmt_files
+#     - filename: uploads/jmt/jmt.conf
+---
+- name: Upload jmt files
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.junction_mapping.import_file
+    isamapi:
+      id: "{{ item.file | basename }}"
+      filename: "{{ inventory_dir }}/{{ item.file }}"
+  with_items: "{{ jmt_files }}"
+  notify: Commit Changes

--- a/web/upload_ltpa_files/defaults/main.yml
+++ b/web/upload_ltpa_files/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for uploading ltpa files
+ltpa_files: []

--- a/web/upload_ltpa_files/meta/main.yml
+++ b/web/upload_ltpa_files/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to upload ltpa files
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - upload
+  - ltpa_files
+
+dependencies:
+  - start_config

--- a/web/upload_ltpa_files/tasks/main.yml
+++ b/web/upload_ltpa_files/tasks/main.yml
@@ -1,0 +1,24 @@
+# main task to upload ltpa files
+# Example:
+#   ltpa_files
+#     - file: uploads/ltpa/default.ltpa
+---
+- name: Upload ltpa files
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.ltpa_key.import_key
+    isamapi:
+      id: "{{ item.file | basename }}"
+      ltpa_keyfile: "{{ inventory_dir }}/{{ item.file }}"
+  with_items: "{{ ltpa_files }}"
+  notify: Commit Changes

--- a/web/upload_management_root_files/defaults/main.yml
+++ b/web/upload_management_root_files/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for uploading management root files
+management_root_files: []

--- a/web/upload_management_root_files/meta/main.yml
+++ b/web/upload_management_root_files/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to upload management root files
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - upload
+  - management_root_file
+
+dependencies:
+  - start_config

--- a/web/upload_management_root_files/tasks/main.yml
+++ b/web/upload_management_root_files/tasks/main.yml
@@ -1,0 +1,27 @@
+# main task to upload management root files
+# Example:
+#   management_root_files:
+#       -   instance_id: default
+#           file: "uploads/management_root/management/C/example.html"
+#           target: "management/C/example.html"
+---
+- name: Upload management root files
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.reverse_proxy.management_root.file.import_file
+    isamapi:
+      id: "{{ item.target }}"
+      filename: "{{ inventory_dir }}/{{ item.file }}"
+      instance_id: "{{ item.instance_id }}"
+  with_items: "{{ management_root_files }}"
+  notify: Commit Changes

--- a/web/upload_runtime_components/defaults/main.yml
+++ b/web/upload_runtime_components/defaults/main.yml
@@ -1,0 +1,2 @@
+# Default variables for uploading runtime components
+runtime_components: []

--- a/web/upload_runtime_components/meta/main.yml
+++ b/web/upload_runtime_components/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to upload runtime components
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - upload
+  - runtime components
+
+dependencies:
+  - start_config

--- a/web/upload_runtime_components/tasks/main.yml
+++ b/web/upload_runtime_components/tasks/main.yml
@@ -1,0 +1,24 @@
+# main task to upload runtime components
+# Example:
+#   runtime_components:
+#     - migrate_file: "{{ inventory_dir }}/uploads/runtime/ldap/ldap.conf"
+---
+- name: Upload runtime components
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.runtime.configuration.file.update
+    isamapi:
+      resource_id:    "{{ item.migrate_file | basename }}"
+      file_contents:  "{{ lookup('template', item.migrate_file) | replace('\n', '\\n') }}"
+  with_items: "{{ runtime_components }}"
+  notify: Commit Changes


### PR DESCRIPTION
1. AdminProxy support:

   Introducing the AdminProxy parameters (adminProxyProtocol, adminProxyHostname, adminProxyPort, adminProxyApplianceShortName, omitAdminProxy) to the isam module.

    E.g.
     - https://adminProxy.ibm.com/isam.ibm.com
       adminProxyProtocol=https (optional)
       adminProxyHostname=isam.ibm.com
       adminProxyPort=443 (optional)
     - https://adminPrxy.ibm.com/isam
       adminProxyProtocol=https (optional)
       adminProxyHostname=isam.ibm.com (necessary for hostname configuration)
       adminProxyPort=443 (optional)
       adminProxyApplianceShortName=true
     - https://isam.ibm.com
       adminProxyProtocol=https (optional)
       adminProxyHostname=isam.ibm.com
       adminProxyPort=443 (optional)
       omitAdminProxy=true (can be used on command line for bypassing the adminProxy)

2. New roles: hierarchically structured

   New roles with hierarchy structure (aac, base, fed, web) is introduced. The roles partially rely on each other

3. new exclude filter

   Problem: Currently it is only possible to pop off an element form a dict with a set_fact workaround. (workaround: https://stackoverflow.com/questions/40496021/how-to-remove-a-single-key-from-an-ansible-dictionary)
   Solution: Adding exclude filter to pop off one element from a dict.
   
   E.g.
      dict = {'a':1, 'b':2}
      dict2 = {{ dict | exclude('b') }}
      
      result
        dict:  {'a':1, 'b':2}
        dict2: {'a':1}