### PR TITLE
Added oidc parameter

### DIFF
--- a/set_oauth_definition/defaults/main.yml
+++ b/set_oauth_definition/defaults/main.yml
@@ -16,3 +16,4 @@ set_oauth_definition_enableMultipleRefreshTokensForFaultTolerance: False
 set_oauth_definition_pinPolicyEnabled                            : False
 set_oauth_definition_pinLength                                   : 4
 set_oauth_definition_tokenCharSet                                : "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+set_oauth_definition_oidc                                        : None

--- a/set_oauth_definition/tasks/main.yml
+++ b/set_oauth_definition/tasks/main.yml
@@ -25,6 +25,7 @@
       pinPolicyEnabled                            : "{{ set_oauth_definition_pinPolicyEnabled }}"
       pinLength                                   : "{{ set_oauth_definition_pinLength }}"
       tokenCharSet                                : "{{ set_oauth_definition_tokenCharSet }}"
+      oidc                                        : "{{ set_oauth_definition_oidc }}"
   when: set_oauth_definition_name is defined
   notify:
   - Commit Changes


### PR DESCRIPTION
I just updated the role, the Python code in aac/api_protection/definitions.py already supports the oidc param.