### PR TITLE
Add optional support for 'comment' parameter of advanced tuning param…

### DIFF
--- a/set_advanced_tuning_parameter/README.md
+++ b/set_advanced_tuning_parameter/README.md
@@ -18,6 +18,7 @@ Provide the option key and value for the advanced tuning parameters to set
       advanced_tuning_parameter_value: "Value 1"
     - advanced_tuning_parameter_key: "Key 2"
       advanced_tuning_parameter_value: "Value 2"
+      advanced_tuning_parameter_comment: "Optional comment"
 ```
 
 The role automatically takes a snapshot before setting advanced tuning parameters, override as needed:
@@ -42,6 +43,7 @@ Here is an example of how to use this role:
                advanced_tuning_parameter_value: "Value 1"
              - advanced_tuning_parameter_key: "Key 2"
                advanced_tuning_parameter_value: "Value 2"
+               advanced_tuning_parameter_comment: "Optional comment"
 
 License
 -------

--- a/set_advanced_tuning_parameter/tasks/main.yml
+++ b/set_advanced_tuning_parameter/tasks/main.yml
@@ -22,6 +22,7 @@
     isamapi:
       key: "{{ item.advanced_tuning_parameter_key }}"
       value: "{{ item.advanced_tuning_parameter_value }}"
+      comment: "{{ item.advanced_tuning_parameter_comment | default(None) }}"
   with_items: "{{ advanced_tuning_parameters }}"
   when: advanced_tuning_parameters is defined
   notify: Commit Changes


### PR DESCRIPTION
…eter

Please review and consider this small enhancement that allows the passing of the 'comment' parameter down to the ibmsecurity python module which already supported.

I made the change in a way that is backward compatible, i.e. not necessitating one to actually have to pass this 'comment' parameter.

Thanks