### PR TITLE
added role to export application log files.

### DIFF
--- a/export_application_logs/defaults/main.yml
+++ b/export_application_logs/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+path: "{{ item.path }}"

--- a/export_application_logs/meta/main.yml
+++ b/export_application_logs/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to export application log files. A downloads folder has to exist in the inventory folder. Inside the downloads folder a folder for each appliance hostname is necessary.
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - export
+  - application log files
+
+dependencies:
+  - start_config

--- a/export_application_logs/tasks/main.yml
+++ b/export_application_logs/tasks/main.yml
@@ -1,0 +1,47 @@
+# main task to export all application log files
+# A downloads folder has to exist in the inventory folder. Inside the downloads folder a folder for each appliance
+# hostname is necessary. It is possible to limit the export using the path variable. E.g append the following to your
+# ansible command: -e path=federation/runtime
+---
+- name: Get application log file list
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.application_logs.get_all
+    isamapi:
+      flat_details: yes
+  register: logs
+  
+- debug: 
+    msg: "{{ item }}"
+  when: path == item.path
+  with_items: "{{ logs.data }}"
+  
+- name: Get application log files
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.application_logs.export_file
+    isamapi:
+      file_path: "{{ item.path }}/{{ item.name }}"
+      filename: "{{ inventory_dir }}/downloads/{{ inventory_hostname }}/{{ item.name }}"
+  when: path == item.path
+  with_items: "{{ logs.data }}"


### PR DESCRIPTION
Hello, 
I added a new role to export application log files. By default the role exports all files to a `downloads` folder inside the inventory folder. It is possible to limit the export by using the `path` variable.
Regards, 
Franz