### PR TITLE
using role variable 'add_system_alerts_rsyslog_name' if defined

### DIFF
--- a/add_system_alerts_rsyslog/tasks/main.yml
+++ b/add_system_alerts_rsyslog/tasks/main.yml
@@ -8,7 +8,7 @@
     force:     "{{ force }}"
     action: ibmsecurity.isam.base.system_alerts.rsyslog.add
     isamapi:
-      name          : "RSyslog Alert to {{ add_system_alerts_rsyslog_collector }}"
+      name          : "{{ add_system_alerts_rsyslog_name | default('RSyslog Alert to ' + add_system_alerts_rsyslog_collector) }}"
       collector     : "{{ add_system_alerts_rsyslog_collector }}"
       collectorPort : "{{ add_system_alerts_rsyslog_collectorPort }}"
       collectorLeef : "{{ add_system_alerts_rsyslog_collectorLeef }}"


### PR DESCRIPTION
Beyond the fact that we may want to use a customized name for the alerts rsyslog entry

If you want to use the collector hostname (which may contains more than 32 caracters) rather than the ip address you got the following exception from the API endpoint
(as the add_system_alerts_rsyslog_collector value is concatenated with 'RSyslog Alert to ' to form the name

**### _HTTP Return code: 400', u'["Name: Field must be between 1 and 50 in length"]')"_**