### PR TITLE
2 new roles and added parameter to API definition

### DIFF
--- a/set_access_policy/README.md
+++ b/set_access_policy/README.md
@@ -1,0 +1,52 @@
+Set Access Policy
+=========
+
+A role for creating or updating an access policy
+
+Requirements
+------------
+
+start_config role is a required dependencies. It contains the Ansible Custom Modules and handlers.
+
+Role Variables
+--------------
+
+Provide the following values for role to succeed
+
+```
+  required
+  set_access_policy_name:
+  
+  set_access_policy_file: 
+  OR
+  set_access_policy_content:
+
+  optional
+  set_access_policy_category: (Default: OIDC)
+  set_access_policy_type: (Default: JavaScript)
+```
+
+Dependencies
+------------
+
+start_config is a required role - since it contains the Ansible Custom Modules and Handlers.
+
+Example Playbook
+----------------
+
+With this playbook you can create or update an access policy
+
+```
+    - hosts: servers
+      connection: local
+      roles:
+        - role: start_config
+        - role: set_access_policy
+          set_access_policy_name: "Policy1"
+          set_access_policy_file: "/path/to/access_policy.js"
+```
+
+License
+-------
+
+Apache

--- a/set_access_policy/defaults/main.yml
+++ b/set_access_policy/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# Provide the following values for role to succeed
+#set_access_policy_name:
+#set_access_policy_file or set_access_policy_content:
+
+# Default values from ibmsecurity python module
+set_access_policy_category: "OIDC"
+set_access_policy_type: "JavaScript"

--- a/set_access_policy/meta/main.yml
+++ b/set_access_policy/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info: 
+  author: IBM
+  description: Role to set access policy
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - set
+  - aac
+  - accesspolicy
+
+dependencies:
+  - start_config

--- a/set_access_policy/tasks/main.yml
+++ b/set_access_policy/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Set an Access Policy - {{set_access_policy_name}}
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.aac.access_policy.set
+    isamapi:
+      name    : "{{ set_access_policy_name }}"
+      category: "{{ set_access_policy_category }}"
+      type    : "{{ set_access_policy_type }}"
+      file    : "{{ set_access_policy_file | default(None) }}"
+      content : "{{ set_access_policy_content | default(None) }}"
+  when: set_access_policy_name is defined
+  notify: Commit Changes

--- a/set_mgmtazn_role_group/defaults/main.yml
+++ b/set_mgmtazn_role_group/defaults/main.yml
@@ -1,0 +1,6 @@
+# Provide a list of groups for this role to work on
+
+#set_mgmtazn_role_groups:
+#  - name: "Security Administrator"
+#    group_name: "administrator-grp"
+#    type: "local"

--- a/set_mgmtazn_role_group/meta/main.yml
+++ b/set_mgmtazn_role_group/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role that sets a group in role for Management Auhtorization
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - management_authorization
+  - role
+  - group
+
+dependencies:
+  - start_config

--- a/set_mgmtazn_role_group/tasks/main.yml
+++ b/set_mgmtazn_role_group/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: Set group into Mgmt Azn Role
+  isam:
+      appliance: "{{ inventory_hostname }}"
+      username:  "{{ username }}"
+      password:  "{{ password }}"
+      lmi_port:  "{{ lmi_port }}"
+      log:       "{{ log_level }}"
+      force:     "{{ force }}"
+      action: ibmsecurity.isam.base.management_authorization.role_group.set
+      isamapi:
+        name:       "{{ item.name }}"
+        group_name: "{{ item.group_name }}"
+        type:       "{{ item.type | default(None) }}"
+  with_items: "{{ set_mgmtazn_role_groups }}"
+  when: set_mgmtazn_role_groups is defined
+  notify:
+    - Commit Changes

--- a/set_oauth_definition/tasks/main.yml
+++ b/set_oauth_definition/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Set a new OAuth 2.0 Definition {{ set_oauth_definition_name }}
+- name: Create or update new OAuth 2.0 Definition {{ set_oauth_definition_name }}
   isam:
     appliance: "{{ inventory_hostname }}"
     username:  "{{ username }}"
@@ -26,6 +26,7 @@
       pinLength                                   : "{{ set_oauth_definition_pinLength }}"
       tokenCharSet                                : "{{ set_oauth_definition_tokenCharSet }}"
       oidc                                        : "{{ set_oauth_definition_oidc }}"
+      accessPolicyName                            : "{{ set_oauth_definition_accessPolicyName }}"
   when: set_oauth_definition_name is defined
   notify:
   - Commit Changes


### PR DESCRIPTION
New roles for setting access policy and adding groups to management authorization roles. New accessPolicyName parameter for API definition added. Pull request that adds the same for ibmsecurity python module waiting (https://github.com/IBM-Security/ibmsecurity/pull/130). This should be merged at the same time with that.