### PR TITLE
Provide support for ZIP archive upload and deletion of unneeded locales

### DIFF
--- a/update_management_root/defaults/main.yml
+++ b/update_management_root/defaults/main.yml
@@ -5,3 +5,9 @@
 #update_management_root_idandfilename:
 #  - {id: "management/C/login.html",   filename: "/mydir/local/login.html"}
 #  - {id: "junction-root/favicon.ico", filename: "/mydir/local/favicon.ico"}
+
+# Provide a management root zip filename (optional)
+#update_management_root_zip_filename:
+
+# Provide a list of locale to delete (optional)
+#update_management_root_locale_exclusion:

--- a/update_management_root/tasks/main.yml
+++ b/update_management_root/tasks/main.yml
@@ -1,4 +1,20 @@
-- name: Update Management Root Files in {{ update_management_root_instance_id }}
+- name: Update Management Root Files in {{ update_management_root_instance_id }} from {{ update_management_root_zip_filename | basename }} archive
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.web.reverse_proxy.management_root.all.import_zip
+    isamapi:
+      instance_id: "{{ update_management_root_instance_id }}"
+      filename : "{{ update_management_root_zip_filename }}"
+  when: update_management_root_instance_id is defined and update_management_root_zip_filename is defined
+  notify:
+  - Commit Changes
+
+- name: Update Management Root Files in {{ update_management_root_instance_id }} from individual updates
   isam:
     appliance: "{{ inventory_hostname }}"
     username:  "{{ username }}"
@@ -13,5 +29,39 @@
       filename   : "{{ item.filename }}"
   with_items: "{{ update_management_root_idandfilename }}"
   when: update_management_root_idandfilename is defined and update_management_root_instance_id is defined
+  notify:
+  - Commit Changes
+
+- name: Delete Management Root 'errors' Directories in {{ update_management_root_instance_id }} for locale {{ update_management_root_locale_exclusion }}
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.web.reverse_proxy.management_root.directory.delete
+    isamapi:
+      instance_id: "{{ update_management_root_instance_id }}"
+      id         : "errors/{{ item }}"
+  with_items: "{{ update_management_root_locale_exclusion }}"
+  when: update_management_root_locale_exclusion is defined
+  notify:
+  - Commit Changes
+
+- name: Delete Management Root 'management' Directories in {{ update_management_root_instance_id }} for locale {{ update_management_root_locale_exclusion }}
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.web.reverse_proxy.management_root.directory.delete
+    isamapi:
+      instance_id: "{{ update_management_root_instance_id }}"
+      id         : "management/{{ item }}"
+  with_items: "{{ update_management_root_locale_exclusion }}"
+  when: update_management_root_locale_exclusion is defined
   notify:
   - Commit Changes


### PR DESCRIPTION
Sample code snippet to use the revised 'update_management_root' role shared here. Adapt it to your working environment and own variables names.

In this sample, we assume that A) only "en" and "fr" locales ressources are to be preserved on the Appliance's WRP, and B) generates an archive (ZIP) before uploading it to the WRP.

```
- name: setup runtime component (ISAM_RP) (archive content)
  hosts: localhost
  vars:
    rp_web_management_root: "{{ lookup('ini', 'management-root type=properties file={{ fact_rp_file }} default=default_root') }}"
  tasks:
    - name: create archive
      archive:
        path:
          - "{{ ansible_env.ISAM_TEMPLATES_HOME }}/isam/web/html/{{ rp_web_management_root }}/*"
        dest: "{{ ansible_env.ISAM_TMP }}/{{ rp_web_management_root }}.zip"
        format: zip
      run_once: True

- name: setup runtime component (ISAM_RP) (upload content)
  hosts: rp_dynamic_list
  serial: 1
  vars:
    username: "{{ fact_va_username }}"
    password: "{{ fact_va_password }}"
    update_management_root_instance_id: "{{ lookup('ini', 'server-name type=properties file={{ fact_rp_file }}') }}"
    rp_web_management_root: "{{ lookup('ini', 'management-root type=properties file={{ fact_rp_file }} default=default_root') }}"
  roles:
    - role: update_management_root
      update_management_root_zip_filename: "{{ ansible_env.ISAM_TMP }}/{{ rp_web_management_root }}.zip"
      update_management_root_locale_exclusion: 
        - "ar"
        - "cs"
        - "de"
        - "es"
        - "hu"
        - "it"
        - "ja"
        - "ko"
        - "pl"
        - "pt_BR"
        - "ru"
        - "zh_CN"
        - "zh_TW"
```
