### PR TITLE
Role to create a new user in the runtime local user registry (eg. eas…

### DIFF
--- a/aac/create_user_registry_user/defaults/main.yml
+++ b/aac/create_user_registry_user/defaults/main.yml
@@ -1,0 +1,4 @@
+# defaults for creating an embedded ldap user
+# Both of these are required variables
+user_registry_user_username: null
+user_registry_user_password: null

--- a/aac/create_user_registry_user/meta/main.yml
+++ b/aac/create_user_registry_user/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role that creates an embedded ldap user
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.6
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - password
+  - user_registry
+  - create
+
+dependencies:
+  - start_config

--- a/aac/create_user_registry_user/tasks/main.yml
+++ b/aac/create_user_registry_user/tasks/main.yml
@@ -1,0 +1,30 @@
+# Role to create a user in the embedded ldap directory
+#
+# Example:
+#   - name: Create easuser in the runtime registry
+#     tags: ["oauth"]
+#     include_role:
+#       name: aac/create_user_registry_user
+#     vars:
+#       user_registry_user_username: "easuser"
+#       user_registry_user_password: "{{ vault_easuser_password }}"
+#
+- name: Create User in the AAC User Registry
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    adminProxyProtocol: "{{ adminProxyProtocol | default(omit) }}"
+    adminProxyHostname: "{{ adminProxyHostname | default(omit) }}"
+    adminProxyPort: "{{ adminProxyPort | default(omit) }}"
+    adminProxyApplianceShortName: "{{ adminProxyApplianceShortName | default(omit) }}"
+    omitAdminProxy: "{{ omitAdminProxy | default(omit) }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ port | default(omit) }}"
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.user_registry.user.add
+    isamapi:
+      id: "{{ user_registry_user_username }}"
+      password: "{{ user_registry_user_password }}"
+  when: user_registry_user_username is defined
+  notify: Commit Changes


### PR DESCRIPTION
Role to use the reorganized aac/user_registry.user.py code, to create a user in the local user registry. (eg. easuser)