### PR TITLE
Add the set_role_group and set_role_user roles to the ISAM Ansible roles

### DIFF
--- a/set_role_group/defaults/main.yml
+++ b/set_role_group/defaults/main.yml
@@ -1,0 +1,3 @@
+# Provide the following values for this role to work
+# Available Group Types: LDAP or Local
+set_role_group_type: ldap

--- a/set_role_group/meta/main.yml
+++ b/set_role_group/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role to set management authorization role group
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - set
+  - base
+  - management_authorization
+
+dependencies:
+  - start_config

--- a/set_role_group/tasks/main.yml
+++ b/set_role_group/tasks/main.yml
@@ -1,0 +1,23 @@
+# Example to add an LDAP group to the Security Administrator management authorization role group
+# - name: set management authorization role group
+#   include_role:
+#     name: set_role_group
+#   vars:
+#     set_role_group_name: Security Administrator
+#     set_role_group_group_name: test_group
+#     set_role_group_type: ldap
+- name: Add a group to a management authorization role group
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.management_authorization.role_group.set
+    isamapi:
+      name: "{{ set_role_group_name }}"
+      group_name: "{{ set_role_group_group_name }}"
+      type: "{{ set_role_group_type }}"
+  when: set_role_group_name is defined and set_role_group_group_name is defined
+  notify: Commit Changes

--- a/set_role_user/defaults/main.yml
+++ b/set_role_user/defaults/main.yml
@@ -1,0 +1,3 @@
+# Provide the following values for this role to work
+# Available Group Types: LDAP or Local
+set_role_group_type: ldap

--- a/set_role_user/meta/main.yml
+++ b/set_role_user/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role to add a user to a management authorization role group
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - set
+  - base
+  - management_authorization
+
+dependencies:
+  - start_config

--- a/set_role_user/tasks/main.yml
+++ b/set_role_user/tasks/main.yml
@@ -1,0 +1,23 @@
+# Example to add an LDAP user to the Security Administrator management authorization role group
+# - name: set management authorization role user
+#   include_role:
+#     name: set_role_user
+#   vars:
+#     set_role_group_name: Security Administrator
+#     set_role_user_user_name: test_user
+#     set_role_user_type: ldap
+- name: Add a user to a management authorization role group
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.management_authorization.role_user.set
+    isamapi:
+      name: "{{ set_role_group_name }}"
+      user_name: "{{ set_role_user_user_name }}"
+      type: "{{ set_role_user_type }}"
+  when: set_role_user_name is defined and set_role_user_user_name is defined
+  notify: Commit Changes


### PR DESCRIPTION
Add the set_role_group and set_role_user roles to the ISAM Ansible roles in order to be able to add a group or a user to a management authorization role group.