### PR TITLE
Role search_attribute_source does not work on ansible 2.8

### DIFF
--- a/search_attribute_source/tasks/main.yml
+++ b/search_attribute_source/tasks/main.yml
@@ -10,4 +10,4 @@
     isamapi:
       name: "{{ search_attribute_source_name }}"
   when: search_attribute_source_name is defined
-  register: "{{ search_attribute_source_register }}"
+  register: search_attribute_source_register


### PR DESCRIPTION
fixes #150 