### PR TITLE
Add the get_federations, get_federation_partners roles, get_certificate_databases, get_personal_certificates and get_signer_certificates to the ISAM Ansible roles

### DIFF
--- a/base/get_certificate_databases/meta/main.yml
+++ b/base/get_certificate_databases/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to get the certificate databases
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - certificate
+
+dependencies:
+  - start_config

--- a/base/get_certificate_databases/tasks/main.yml
+++ b/base/get_certificate_databases/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Get the certificate databases
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.ssl_certificates.certificate_databases.get_all
+  register: ret_obj
+
+- name: set a fact to be used by other components
+  set_fact:
+    get_certificate_databases_ret_obj: "{{ ret_obj['data'] }}"

--- a/base/get_personal_certificates/meta/main.yml
+++ b/base/get_personal_certificates/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to get the personal certificates
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - certificate
+
+dependencies:
+  - start_config

--- a/base/get_personal_certificates/tasks/main.yml
+++ b/base/get_personal_certificates/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: Get the personal certificates
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.ssl_certificates.personal_certificate.get_all
+    isamapi:
+      kdb_id: "{{ get_personal_certificates_kdb_id }}"
+  register: ret_obj
+
+- name: set a fact to be used by other components
+  set_fact:
+    get_personal_certificates_ret_obj: "{{ ret_obj['data'] }}"

--- a/base/get_signer_certificates/meta/main.yml
+++ b/base/get_signer_certificates/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to get the signer certificates
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - certificate
+
+dependencies:
+  - start_config

--- a/base/get_signer_certificates/tasks/main.yml
+++ b/base/get_signer_certificates/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: Get the signer certificates
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.ssl_certificates.signer_certificate.get_all
+    isamapi:
+      kdb_id: "{{ get_signer_certificates_kdb_id }}"
+  register: ret_obj
+
+- name: set a fact to be used by other components
+  set_fact:
+    get_signer_certificates_ret_obj: "{{ ret_obj['data'] }}"

--- a/fed/get_federation_partners/meta/main.yml
+++ b/fed/get_federation_partners/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to get the federation partners
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - federation
+
+dependencies:
+  - start_config

--- a/fed/get_federation_partners/tasks/main.yml
+++ b/fed/get_federation_partners/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: "Get the federation partners - {{ get_federation_partners_federation_name }}"
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.fed.partners.get_all
+    isamapi:
+      federation_name: "{{ get_federation_partners_federation_name }}"
+  register: ret_obj
+
+- name: Set variable for use by rest of playbook
+  set_fact:
+    get_federation_partners_ret_obj: "{{ ret_obj['data'] }}"

--- a/fed/get_federations/meta/main.yml
+++ b/fed/get_federations/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role that gets all federations in an appliance
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - federation
+  - get
+
+dependencies:
+  - start_config

--- a/fed/get_federations/tasks/main.yml
+++ b/fed/get_federations/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Get all the federations
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.fed.federations.get_all
+  register: ret_obj
+
+- name: Set variable for use by rest of playbook
+  set_fact:
+    get_federations_ret_obj: "{{ ret_obj['data'] }}"


### PR DESCRIPTION
Add the get_federations, get_federation_partners roles, get_certificate_databases, get_personal_certificates and get_signer_certificates to the ISAM Ansible roles in order to be able to extract all the data for the federations, the federation partners and the certificates