### PR TITLE
Compatible import for StringIO

### DIFF
--- a/start_config/library/isam.py
+++ b/start_config/library/isam.py
@@ -5,8 +5,12 @@ import logging.config
 import sys
 import importlib
 from ansible.module_utils.basic import AnsibleModule
-from io import StringIO
 import datetime
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from ibmsecurity.appliance.isamappliance import ISAMAppliance
 from ibmsecurity.appliance.isamappliance_adminproxy import ISAMApplianceAdminProxy

--- a/start_config/library/isamadmin.py
+++ b/start_config/library/isamadmin.py
@@ -5,8 +5,12 @@ import logging.config
 import sys
 import importlib
 from ansible.module_utils.basic import AnsibleModule
-from io import StringIO
 import datetime
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from ibmsecurity.appliance.isamappliance import ISAMAppliance
 from ibmsecurity.appliance.isamappliance_adminproxy import ISAMApplianceAdminProxy

--- a/start_config/library/isamcompare.py
+++ b/start_config/library/isamcompare.py
@@ -5,8 +5,12 @@ import logging.config
 import sys
 import importlib
 from ansible.module_utils.basic import AnsibleModule
-from io import StringIO
 import datetime
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from ibmsecurity.appliance.isamappliance import ISAMAppliance
 from ibmsecurity.appliance.ibmappliance import IBMError


### PR DESCRIPTION
@Ram this should resolve compatibility issue for both Python.
However, I only tested with Python V2.X.
Thanks
