### PR TITLE
Add multiple Ansible roles to the project

### DIFF
--- a/add_reverseproxy_conf_stanza/defaults/main.yml
+++ b/add_reverseproxy_conf_stanza/defaults/main.yml
@@ -1,0 +1,6 @@
+# Provide the name of the reverse proxy to update
+#add_reverseproxy_conf_stanza_reverseproxy_id: "default"
+
+# Provide entries in the following format. Create an array for each value to be updated.
+#add_reverseproxy_conf_stanza_stanzas:
+#  - stanza_id: "server"

--- a/add_reverseproxy_conf_stanza/meta/main.yml
+++ b/add_reverseproxy_conf_stanza/meta/main.yml
@@ -1,0 +1,19 @@
+galaxy_info:
+  author: IBM
+  description: Role to add to reverse proxy configuration file with given stanza
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - reverseproxy
+  - web
+  - configuration
+  - add
+
+dependencies:
+  - start_config

--- a/add_reverseproxy_conf_stanza/tasks/main.yml
+++ b/add_reverseproxy_conf_stanza/tasks/main.yml
@@ -1,0 +1,17 @@
+# Update existing stanza(s)/entries in reverse proxy config file
+- name: Configure Reverse Proxy stanza(s) (Adds)
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.web.reverse_proxy.configuration.stanza.add
+    isamapi:
+      reverseproxy_id: "{{ add_reverseproxy_conf_stanza_reverseproxy_id }}"
+      stanza_id:       "{{ item.stanza_id }}"
+  with_items:          "{{ add_reverseproxy_conf_stanza_stanzas }}"
+  when: add_reverseproxy_conf_stanza_stanzas is defined and add_reverseproxy_conf_stanza_reverseproxy_id is defined
+  notify:
+  - Commit Changes

--- a/delete_certificate_db/meta/main.yml
+++ b/delete_certificate_db/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role to delete certificate db
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - delete
+  - certificate
+  - db
+
+dependencies:
+  - start_config

--- a/delete_certificate_db/tasks/main.yml
+++ b/delete_certificate_db/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: Deleting certificate database
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.ssl_certificates.certificate_databases.delete
+    isamapi:
+      cert_dbase_id: "{{ delete_certificate_db }}"
+  notify:
+    - Commit Changes

--- a/delete_management_root_file/meta/main.yml
+++ b/delete_management_root_file/meta/main.yml
@@ -1,0 +1,19 @@
+galaxy_info:
+  author: IBM
+  description: Role to delete a file in Management Root of Reverse Proxy
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - reverseproxy
+  - management root
+  - file
+  - delete
+
+dependencies:
+  - start_config

--- a/delete_management_root_file/tasks/main.yml
+++ b/delete_management_root_file/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: Delete Management Root File/folder {{ delete_management_root_file_filename }} from {{ delete_management_root_file_instance_id }}
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.web.reverse_proxy.management_root.directory.delete
+    isamapi:
+      instance_id: "{{ delete_management_root_file_instance_id }}"
+      id: "{{ delete_management_root_file_filename }}"
+  when: delete_management_root_file_instance_id is defined and delete_management_root_file_filename is defined
+  notify:
+  - Commit Changes

--- a/delete_reverseproxy_conf_stanza/meta/main.yml
+++ b/delete_reverseproxy_conf_stanza/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role to delete stanzas
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - delete
+  - web
+  - stanzas
+
+dependencies:
+  - start_config

--- a/delete_reverseproxy_conf_stanza/tasks/main.yml
+++ b/delete_reverseproxy_conf_stanza/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: Delete stanzas
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.web.reverse_proxy.configuration.stanza.delete
+    isamapi:
+      stanza_id           : "{{ item.stanza_id }}"
+      reverseproxy_id       : "{{ delete_reverseproxy_conf_stanza_reverseproxy_id }}"
+  with_items: "{{ delete_reverseproxy_conf_stanza_entries }}"
+  when: delete_reverseproxy_conf_stanza_entries is defined and delete_reverseproxy_conf_stanza_reverseproxy_id is defined
+  notify:
+    - Commit Changes
+    - Restart Reverse Proxy

--- a/delete_rsyslog_forwarder/meta/main.yml
+++ b/delete_rsyslog_forwarder/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role to delete a Remote Syslog Forwarder
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - remote
+  - syslog
+  - forwarder
+
+dependencies:
+  - start_config

--- a/delete_rsyslog_forwarder/tasks/main.yml
+++ b/delete_rsyslog_forwarder/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: Deleting "{{ delete_rsyslog_fowarder_server }}:{{ delete_rsyslog_fowarder_port }}" from Rsyslog Forwarder
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.remote_syslog.forwarder.delete
+    isamapi:
+      server:   "{{ delete_rsyslog_fowarder_server }}"
+      port:     "{{ delete_rsyslog_fowarder_port }}"
+      protocol: "{{ delete_rsyslog_fowarder_protocol }}"
+  when: delete_rsyslog_fowarder_server is defined and delete_rsyslog_fowarder_port is defined and delete_rsyslog_fowarder_protocol is defined
+  notify: Commit Changes

--- a/delete_rsyslog_forwarder_sources/meta/main.yml
+++ b/delete_rsyslog_forwarder_sources/meta/main.yml
@@ -1,0 +1,19 @@
+galaxy_info:
+  author: IBM
+  description: Role to delete Remote Syslog Forwarder Sources
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - remote
+  - syslog
+  - forwarder
+  - sources
+
+dependencies:
+  - start_config

--- a/delete_rsyslog_forwarder_sources/tasks/main.yml
+++ b/delete_rsyslog_forwarder_sources/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: Deleting {{ delete_rsyslog_fowarder_sources_name }} from {{ delete_rsyslog_fowarder_sources_server }}:{{ delete_rsyslog_fowarder_sources_port }}
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.remote_syslog.forwarder_sources.delete
+    isamapi:
+      server:   "{{ delete_rsyslog_fowarder_sources_server }}"
+      port:     "{{ delete_rsyslog_fowarder_sources_port }}"
+      protocol: "{{ delete_rsyslog_fowarder_sources_protocol }}"
+      name:     "{{ delete_rsyslog_fowarder_sources_name }}"
+  when: delete_rsyslog_fowarder_sources_server is defined and delete_rsyslog_fowarder_sources_port is defined and delete_rsyslog_fowarder_sources_protocol is defined and delete_rsyslog_fowarder_sources_name is defined
+  notify: Commit Changes

--- a/delete_sysaccount_user/defaults/main.yml
+++ b/delete_sysaccount_user/defaults/main.yml
@@ -1,0 +1,4 @@
+#Provide a system account name, password and collection of group memberships
+delete_sysaccount_id : null
+delete_sysaccount_password: null
+delete_sysaccount_groups: null

--- a/delete_sysaccount_user/meta/main.yml
+++ b/delete_sysaccount_user/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role that delete a sysaccount_user
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - remove
+  - LMI
+  - user
+
+dependencies:
+  - start_config

--- a/delete_sysaccount_user/tasks/main.yml
+++ b/delete_sysaccount_user/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: Delete LMI system account user
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.sysaccount.users.delete
+    isamapi:
+      id : "{{ delete_sysaccount_id }}"
+  when: delete_sysaccount_id is defined
+  notify: Commit Changes

--- a/delete_system_alerts_rsyslog/meta/main.yml
+++ b/delete_system_alerts_rsyslog/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to update a System Alert to Remote Syslog Server
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - monitoring
+  - alerts
+
+dependencies:
+  - start_config

--- a/delete_system_alerts_rsyslog/tasks/main.yml
+++ b/delete_system_alerts_rsyslog/tasks/main.yml
@@ -1,0 +1,27 @@
+- name: Getting uuid of System Alert Rsyslog to delete
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.system_alerts.rsyslog.search
+    isamapi:
+      collector: "{{ system_alerts_rsyslog_collector }}"
+  when: system_alerts_rsyslog_collector is defined
+  register: sysalerts_rsyslog
+
+- name: Deleting {{ system_alerts_rsyslog_collector }} from rsyslog system alerts
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.system_alerts.rsyslog.delete
+    isamapi:
+      uuid: "{{ sysalerts_rsyslog['data'] }}"
+  when: sysalerts_rsyslog['data'] is defined
+  notify: Commit Changes

--- a/delete_system_alerts_snmp/meta/main.yml
+++ b/delete_system_alerts_snmp/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role to delete system alerts SNMP
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - delete
+  - alerts
+  - snmp
+
+dependencies:
+  - start_config

--- a/delete_system_alerts_snmp/tasks/main.yml
+++ b/delete_system_alerts_snmp/tasks/main.yml
@@ -1,0 +1,50 @@
+- name: Getting UUIDs of SNMP trapAddresses
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.system_alerts.snmp.get_all
+  register: snmp_objects
+
+- name: Initialize UUIDs array
+  set_fact:
+    snmp_uuids_to_delete: []
+
+- name: Gettings UUIDs to delete
+  set_fact:
+    snmp_uuids_to_delete: "{{ snmp_uuids_to_delete + [item.uuid] }}"
+  with_items: "{{ snmp_objects['data']['snmpObjects'] }}"
+  when: delete_system_alerts_snmp_trapAddress is defined and item.trapAddress in delete_system_alerts_snmp_trapAddress
+
+- name: Disable System Alerts SNMP before deleting
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.system_alerts.alerts.disable
+    isamapi:
+      uuid: "{{ item }}"
+  with_items: "{{ snmp_uuids_to_delete }}"
+  when: snmp_uuids_to_delete is defined
+  notify: Commit Changes
+
+- name: Delete System Alerts SNMP
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.system_alerts.snmp.delete
+    isamapi:
+      uuid: "{{ item }}"
+  with_items: "{{ snmp_uuids_to_delete }}"
+  when: snmp_uuids_to_delete is defined
+  notify: Commit Changes

--- a/download_latest_snapshot/meta/main.yml
+++ b/download_latest_snapshot/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IFC
+  description: Role to download the latest snapshot
+  company: IFC
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - snapshot
+  - create
+
+dependencies:
+  - start_config

--- a/download_latest_snapshot/tasks/main.yml
+++ b/download_latest_snapshot/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: download latest snapshot from appliance
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action    : ibmsecurity.isam.base.snapshots.download_latest
+    isamapi:
+      dir : "{{ download_latest_snapshot_dir }}"

--- a/download_latest_support/meta/main.yml
+++ b/download_latest_support/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IFC
+  description: Role to download the latest support file
+  company: IFC
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - snapshot
+  - create
+
+dependencies:
+  - start_config

--- a/download_latest_support/tasks/main.yml
+++ b/download_latest_support/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: download latest support file from appliance
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action    : ibmsecurity.isam.base.support.download_latest
+    isamapi:
+      dir : "{{ download_latest_support_dir }}"

--- a/get_licenses/meta/main.yml
+++ b/get_licenses/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IFC
+  description: Role that gets support license
+  company: IFC
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - firmware
+  - get
+
+dependencies:
+  - start_config

--- a/get_licenses/tasks/main.yml
+++ b/get_licenses/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Get Support License installed
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.license.get_all
+  register: ret_obj
+
+- name: Set variable for use by rest of playbook
+  set_fact:
+    licenses_ret_obj: "{{ ret_obj }}"

--- a/get_mapping_rules/defaults/main.yml
+++ b/get_mapping_rules/defaults/main.yml
@@ -1,0 +1,2 @@
+# Provide the following values for role to succeed
+#mapping_rule_name:

--- a/get_mapping_rules/meta/main.yml
+++ b/get_mapping_rules/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role to get a mapping rule
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - set
+  - aac
+  - mappingrule
+
+dependencies:
+  - start_config

--- a/get_mapping_rules/tasks/main.yml
+++ b/get_mapping_rules/tasks/main.yml
@@ -1,0 +1,24 @@
+- name: Get all the mapping rules
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.aac.mapping_rules.get_all
+  register: mapping_rule_objects
+
+- name: Initialize mapping rules array
+  set_fact:
+    mapping_rules_ret_obj: []
+
+- name: Export the mapping rules to an array
+  set_fact:
+    mapping_rules_ret_obj: "{{ mapping_rules_ret_obj + [ item ] }}"
+  with_items: "{{ mapping_rule_objects['data'] }}"
+  no_log: True
+
+- name: set a variable to be used by the other playbooks
+  set_fact:
+    mappingrules_ret_obj: "{{ mapping_rules_ret_obj }}"

--- a/get_modules/meta/main.yml
+++ b/get_modules/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IFC
+  description: Role that gets activation modules
+  company: IFC
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - firmware
+  - get
+
+dependencies:
+  - start_config

--- a/get_modules/tasks/main.yml
+++ b/get_modules/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Get Activated Modules
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.activation.get
+  register: ret_obj
+
+- name: Set variable for use by rest of playbook
+  set_fact:
+    modules_ret_obj: "{{ ret_obj }}"

--- a/get_personal_certificates/defaults/main.yml
+++ b/get_personal_certificates/defaults/main.yml
@@ -1,0 +1,1 @@
+get_personal_certificates_export_csv_data: false

--- a/get_personal_certificates/meta/main.yml
+++ b/get_personal_certificates/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to get the personal certificates
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - certificate
+
+dependencies:
+  - start_config

--- a/get_personal_certificates/tasks/main.yml
+++ b/get_personal_certificates/tasks/main.yml
@@ -1,0 +1,16 @@
+- name: Get the personal certificates for {{ get_personal_certificates_kdb_id }}
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.ssl_certificates.personal_certificate.get_all
+    isamapi:
+      kdb_id: "{{ get_personal_certificates_kdb_id }}"
+  register: ret_obj
+
+- name: set a fact to be used by other components
+  set_fact:
+    get_personal_certificates_ret_obj: "{{ ret_obj['data'] }}"

--- a/get_reverse_proxy/meta/main.yml
+++ b/get_reverse_proxy/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to get a reverse proxy stanza
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - reverse_proxy
+  - stanza
+
+dependencies:
+  - start_config

--- a/get_reverse_proxy/tasks/main.yml
+++ b/get_reverse_proxy/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: Get the reverse proxy namespaces
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.web.reverse_proxy.instance.get
+  register: ret_obj
+
+- name: set a fact to be used by other components
+  set_fact:
+    get_reverse_proxy_ret_obj: "{{ ret_obj['data'] }}"
+

--- a/get_reverse_proxy_stanzas/meta/main.yml
+++ b/get_reverse_proxy_stanzas/meta/main.yml
@@ -1,0 +1,16 @@
+galaxy_info:
+  author: IBM
+  description: Role to get the reverse proxy namespaces
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - reverse_proxy
+
+dependencies:
+  - start_config

--- a/get_reverse_proxy_stanzas/tasks/main.yml
+++ b/get_reverse_proxy_stanzas/tasks/main.yml
@@ -1,0 +1,17 @@
+- name: Get a reverse proxy stanza
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.web.reverse_proxy.configuration.entry.get_all
+    isamapi:
+      reverseproxy_id: "{{ get_reverse_proxy_stanzas_reverseproxy_id }}"
+      stanza_id: "{{ get_reverse_proxy_stanzas_stanza_id }}"
+  register: ret_obj
+
+- name: set a fact to be used by other components
+  set_fact:
+    get_reverse_proxy_stanzas_ret_obj: "{{ ret_obj['data'] }}"

--- a/get_snapshots/meta/main.yml
+++ b/get_snapshots/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IFC
+  description: Role that gets snapshots
+  company: IFC
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - snapshots
+  - get
+
+dependencies:
+  - start_config

--- a/get_snapshots/tasks/main.yml
+++ b/get_snapshots/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Get snapshots on appliance
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action:    ibmsecurity.isam.base.snapshots.get
+  register:    ret_obj
+
+- name: Set variable for use by rest of playbook
+  set_fact:
+    snapshots_ret_obj: "{{ ret_obj }}"

--- a/get_support_files/meta/main.yml
+++ b/get_support_files/meta/main.yml
@@ -1,0 +1,19 @@
+galaxy_info:
+  author: IFC
+  description: Role that gets support files
+  company: IFC
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - support
+  - files
+  - get
+
+dependencies:
+  - start_config
+

--- a/get_support_files/tasks/main.yml
+++ b/get_support_files/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Get support files on appliance
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action:    ibmsecurity.isam.base.support.get
+  register:    ret_obj
+
+- name: Set variable for use by rest of playbook
+  set_fact:
+    support_files_ret_obj: "{{ ret_obj }}"

--- a/remove_sysaccount_user/meta/main.yml
+++ b/remove_sysaccount_user/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role to remove a LMI user
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - remove
+  - LMI
+  - user
+
+dependencies:
+  - start_config

--- a/remove_sysaccount_user/tasks/main.yml
+++ b/remove_sysaccount_user/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: Remove LMI user
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.sysaccount.users.delete
+    isamapi:
+      id: "{{ lmi_user_name }}"
+  notify: Commit Changes

--- a/set_managementauthorization_role/defaults/main.yml
+++ b/set_managementauthorization_role/defaults/main.yml
@@ -1,6 +1,0 @@
-# Provide entries in the following format. Create an array for each value to be updated.
-#
-#set_managementauthorization_role_name: "System Administrator"
-#set_managementauthorization_role_entries:
-#  - { feature_name: "webseal_instances", access: "w" }
-#

--- a/set_managementauthorization_role/defaults/main.yml
+++ b/set_managementauthorization_role/defaults/main.yml
@@ -1,0 +1,6 @@
+# Provide entries in the following format. Create an array for each value to be updated.
+#
+#set_managementauthorization_role_name: "System Administrator"
+#set_managementauthorization_role_entries:
+#  - { feature_name: "webseal_instances", access: "w" }
+#

--- a/set_managementauthorization_role/meta/main.yml
+++ b/set_managementauthorization_role/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
-  author: IFC
+  author: IBM
   description: Role to set a new or existing authorization role with given name and features associated
-  company: IFC
+  company: IBM
 
   license: Apache
 

--- a/set_managementauthorization_role/meta/main.yml
+++ b/set_managementauthorization_role/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IFC
+  description: Role to set a new or existing authorization role with given name and features associated
+  company: IFC
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - configuration
+  - set
+
+dependencies:
+  - start_config

--- a/set_managementauthorization_role/tasks/main.yml
+++ b/set_managementauthorization_role/tasks/main.yml
@@ -1,0 +1,47 @@
+- name: snapshot before management authorization role update
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    lmi_port: "{{ lmi_port }}"
+    log: "{{ log_level }}"
+    force: "{{ force }}"
+    action: ibmsecurity.isam.base.snapshots.create
+    isamapi:
+      comment: "Snapshot Before Management Authorization Role Update"
+
+- name: add management authorization roles
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.management_authorization.role.add
+    isamapi:
+      name  : "{{ item.name }}"
+  with_items: "{{ set_managementauthorization_role_list }}"
+  when: item.name is defined
+
+# Commit changes before next step
+- meta: flush_handlers
+
+- name: set features for management authorization roles
+  isam:
+   appliance: "{{ inventory_hostname }}"
+   username:  "{{ username }}"
+   password:  "{{ password }}"
+   lmi_port:  "{{ lmi_port }}"
+   log:       "{{ log_level }}"
+   force:     "{{ force }}"
+   action: ibmsecurity.isam.base.management_authorization.role_feature.set
+   isamapi:
+     name: "{{ item.0.name }}"
+     feature_name: "{{ item.1.feature_name }}"
+     access: "{{ item.1.access }}"
+  with_subelements:
+    - "{{ set_managementauthorization_role_list }}"
+    - entries
+  when: set_managementauthorization_role_list is defined
+  notify: Commit Changes

--- a/set_runtime_conf/defaults/main.yml
+++ b/set_runtime_conf/defaults/main.yml
@@ -1,0 +1,14 @@
+# Provide entries in the following format. Create an array for each value to be updated.
+#
+#set_runtime_conf_entries:
+#  - resource_id: ldap.conf
+#    stanza_id: "ldap"
+#    entries:  "[['key', 'value']]"
+# #or for multiple values
+#    entries:  "[['key', 'value1'], ['key', 'value2'], ['key', 'value3']]"
+#
+# or use the single line syntax:
+#
+#set_runtime_conf_entries:
+#  - { resource_id: "ldap.conf", stanza_id: "ldap", entries: "[['key','value1']]" }
+#

--- a/set_runtime_conf/meta/main.yml
+++ b/set_runtime_conf/meta/main.yml
@@ -1,0 +1,19 @@
+galaxy_info:
+  author: IFC
+  description: Role to set runtime uproxy configuration file with given stanza/entries
+  company: IFC
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - reverseproxy
+  - web
+  - configuration
+  - set
+
+dependencies:
+  - start_config

--- a/set_runtime_conf/meta/main.yml
+++ b/set_runtime_conf/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
-  author: IFC
+  author: IBM
   description: Role to set runtime uproxy configuration file with given stanza/entries
-  company: IFC
+  company: IBM
 
   license: Apache
 

--- a/set_runtime_conf/tasks/main.yml
+++ b/set_runtime_conf/tasks/main.yml
@@ -1,0 +1,19 @@
+# Set existing stanza(s)/entries in runtime config file
+- name: Configure Runtime stanza(s) entries (Set)
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.web.runtime.configuration.entry.set
+    isamapi:
+      resource_id : "{{ item.resource_id }}"
+      stanza_id:    "{{ item.stanza_id }}"
+      entries:      "{{ item.entries }}"
+  with_items:       "{{ set_runtime_conf_entries }}"
+  when: set_runtime_conf_entries is defined
+  notify:
+  - Commit Changes
+  - Restart Web Runtime

--- a/set_sysaccount_pw/defaults/main.yml
+++ b/set_sysaccount_pw/defaults/main.yml
@@ -1,2 +1,0 @@
-# Standard variables password needs to be defined - this is the new password
-# password needs to have the new password

--- a/set_sysaccount_pw/defaults/main.yml
+++ b/set_sysaccount_pw/defaults/main.yml
@@ -1,0 +1,2 @@
+# Standard variables password needs to be defined - this is the new password
+# password needs to have the new password

--- a/set_sysaccount_pw/meta/main.yml
+++ b/set_sysaccount_pw/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role that sets password for an LMI user
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - password
+  - admin
+  - set
+
+dependencies:
+  - start_config

--- a/set_sysaccount_pw/tasks/main.yml
+++ b/set_sysaccount_pw/tasks/main.yml
@@ -10,6 +10,6 @@
     isamapi:
       id: "{{ set_sysaccount_id }}"
       password: "{{ set_sysaccount_password }}"
-  ignore_errors: true
+  ignore_errors: True
   when: set_sysaccount_id is defined and set_sysaccount_password is defined
   notify: Commit Changes

--- a/set_sysaccount_pw/tasks/main.yml
+++ b/set_sysaccount_pw/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: Change LMI password
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.sysaccount.users.modify
+    isamapi:
+      id: "{{ set_sysaccount_id }}"
+      password: "{{ set_sysaccount_password }}"
+  ignore_errors: true
+  when: set_sysaccount_id is defined and set_sysaccount_password is defined
+  notify: Commit Changes

--- a/unconfig_junctions/defaults/main.yml
+++ b/unconfig_junctions/defaults/main.yml
@@ -1,2 +1,0 @@
-# The following need to be provided for this role to succeed
-#unconfig_junctions_reverseproxy_id:

--- a/unconfig_junctions/defaults/main.yml
+++ b/unconfig_junctions/defaults/main.yml
@@ -1,0 +1,2 @@
+# The following need to be provided for this role to succeed
+#unconfig_junctions_reverseproxy_id:

--- a/unconfig_junctions/meta/main.yml
+++ b/unconfig_junctions/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
-  author: IFC
+  author: IBM
   description: Role to unconfigure all junctions to a reverse proxy
-  company: IFC
+  company: IBM
 
   license: Apache
 

--- a/unconfig_junctions/meta/main.yml
+++ b/unconfig_junctions/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IFC
+  description: Role to unconfigure all junctions to a reverse proxy
+  company: IFC
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - reverse proxy
+  - junction
+  - unconfig
+
+dependencies:
+  - start_config

--- a/unconfig_junctions/tasks/main.yml
+++ b/unconfig_junctions/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: unconfigure all junctions for reverse proxy {{ unconfig_junctions_reverseproxy_id }}
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.web.reverse_proxy.junctions.delete_all
+    isamapi:
+      reverseproxy_id: "{{ unconfig_junctions_reverseproxy_id }}"
+  when: unconfig_junctions_reverseproxy_id is defined

--- a/unconfig_snmp_monitoring/meta/main.yml
+++ b/unconfig_snmp_monitoring/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to unconfigure SNMP Monitoring for an appliance
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - monitoring
+  - snmp
+
+dependencies:
+  - start_config

--- a/unconfig_snmp_monitoring/tasks/main.yml
+++ b/unconfig_snmp_monitoring/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: Unconfigure SNMP Monitoring
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.snmp_monitoring.disable
+    isamapi:
+  notify: Commit Changes

--- a/unset_host_records/meta/main.yml
+++ b/unset_host_records/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: IBM
+  description: Role to unset a host record from host files
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - delete
+  - host
+  - record
+
+dependencies:
+  - start_config

--- a/unset_host_records/tasks/main.yml
+++ b/unset_host_records/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Unset Host Records
+  isam:
+    appliance: "{{ inventory_hostname }}"
+    username:  "{{ username }}"
+    password:  "{{ password }}"
+    lmi_port:  "{{ lmi_port }}"
+    log:       "{{ log_level }}"
+    force:     "{{ force }}"
+    action: ibmsecurity.isam.base.host.records.delete
+    isamapi:
+      host_address: "{{ item.addr }}"
+  when: unset_host_records is defined
+  with_items: "{{ unset_host_records }}"
+  notify: Commit Changes


### PR DESCRIPTION
Add multiple Ansible roles to the project that could be useful to the community.

Here's the list of roles that were added: 

1. delete_certificate_db
2. delete_management_root_file
3. delete_reverseproxy_conf_stanza
4. delete_rsyslog_forwarder
5. delete_rsyslog_forwarder_source
6. delete_sysaccount_user
7. delete_system_alerts_rsyslog
8. delete_system_alerts_snmp
9. download_latest_snapshot
10. download_latest_support
11. get_licenses
12. get_mapping_rules
13. get_modules
14. get_reverse_proxy
15. get_reverse_proxy_stanzas
16. get_snapshots
17. set_managementauthorization_role
18. set_runtime_conf
19. set_sysaccount_pw
20. unconfig_junctions
21. unconfig_snmp_monitoring
22. unset_host_records

