### PR TITLE
Restart LMI after certificate update

### DIFF
--- a/update_management_ssl_cert/tasks/main.yml
+++ b/update_management_ssl_cert/tasks/main.yml
@@ -11,4 +11,8 @@
       certificate   : "{{ update_management_ssl_cert_cert }}"
       password      : "{{ update_management_ssl_cert_pwd }}"
   when: update_management_ssl_cert_cert is defined and update_management_ssl_cert_pwd is defined
-  notify: Commit Changes
+  notify: 
+    - Commit Changes
+    - Restart LMI
+    - Await Appliance LMI Response
+


### PR DESCRIPTION
When updating LMI certificates `Update management ssl certificate` role, the LMI should be restarted so the new certificates are loaded. Failing to do so, the LMI will continue to present old certificates.